### PR TITLE
initial draft for logins component docs

### DIFF
--- a/docs/features/firefox-sync/bookmarks-feature.md
+++ b/docs/features/firefox-sync/bookmarks-feature.md
@@ -11,9 +11,9 @@ sidebar_label: Bookmarks
 
 ### Features
 
-## Fennec Password Management
+## Fennec Bookmark Management
 
-## Mobile Password Management powered by the **Places Component**
+## Mobile Bookmark Management powered by the **Places Component**
 - **Component Owner**: Firefox Sync team.
 - **Component Source**: [mozilla/application-services](https://github.com/mozilla/application-services/tree/master/components/places) repository
 

--- a/docs/features/firefox-sync/bookmarks-feature.md
+++ b/docs/features/firefox-sync/bookmarks-feature.md
@@ -1,0 +1,38 @@
+---
+id: bookmarks-feature
+title: Bookmarks feature
+sidebar_label: Bookmarks
+---
+## Bookmarks Storage and Syncing
+
+**Feature owner**:
+
+## Desktop Bookmark Management
+
+### Features
+
+## Fennec Password Management
+
+## Mobile Password Management powered by the **Places Component**
+- **Component Owner**: Firefox Sync team.
+- **Component Source**: [mozilla/application-services](https://github.com/mozilla/application-services/tree/master/components/places) repository
+
+Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus winter purslane kale. Celery potato scallion desert raisin horseradish spinach carrot soko. Lotus root water spinach fennel kombu maize bamboo shoot green bean swiss chard seakale pumpkin onion chickpea gram corn pea. Brussels sprout coriander water chestnut gourd swiss chard wakame kohlrabi beetroot carrot watercress. Corn amaranth salsify bunya nuts nori azuki bean chick
+
+### Why should I use the bookmarks (places) component?
+Building password management support via the Login component means that a team can have a core shared codebase in Rust, wrapped in native language bindings for supported platforms. Adding password syncing to a browser or browser-like application can be accomplished without having to worry about all the implementation details involved with syncing, storing and encrypting username and password data.
+
+### What features are currently supported?
+- Create, Update and Delete (CRUD) operations for bookmarks
+- Syncing of bookmarks for devices and apps connected via Firefox Accounts
+- Data migration functionality from Fennec to Firefox Preview storage
+- ... more here
+
+### Where can I learn more?
+The [places component readme](https://github.com/mozilla/application-services/blob/master/components/places/README.md) details how to use, test, measure and monitor it.
+
+### Success stories
+Maybe?
+
+#### Adding Bookmarks syncing to Firefox for iOS and Firefox Preview
+Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus winter purslane kale. Celery potato scallion desert raisin horseradish spinach carrot soko.

--- a/docs/features/firefox-sync/history-feature.md
+++ b/docs/features/firefox-sync/history-feature.md
@@ -1,0 +1,38 @@
+---
+id: history-feature
+title: History feature
+sidebar_label: History
+---
+## History Storage and Syncing
+
+**Feature owner**:
+
+## Desktop History Management
+
+### Features
+
+## Fennec History Management
+
+## Mobile Password Management powered by the **Places Component**
+- **Component Owner**: Firefox Sync team.
+- **Component Source**: [mozilla/application-services](https://github.com/mozilla/application-services/tree/master/components/places) repository
+
+Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus winter purslane kale. Celery potato scallion desert raisin horseradish spinach carrot soko. Lotus root water spinach fennel kombu maize bamboo shoot green bean swiss chard seakale pumpkin onion chickpea gram corn pea. Brussels sprout coriander water chestnut gourd swiss chard wakame kohlrabi beetroot carrot watercress. Corn amaranth salsify bunya nuts nori azuki bean chick
+
+### Why should I use the History (places) component?
+Building password management support via the Login component means that a team can have a core shared codebase in Rust, wrapped in native language bindings for supported platforms. Adding password syncing to a browser or browser-like application can be accomplished without having to worry about all the implementation details involved with syncing, storing and encrypting username and password data.
+
+### What features are currently supported?
+- Create, Update and Delete (CRUD) operations for History
+- Syncing of History for devices and apps connected via Firefox Accounts
+- Data migration functionality from Fennec to Firefox Preview storage
+- ... more here
+
+### Where can I learn more?
+The [places component readme](https://github.com/mozilla/application-services/blob/master/components/places/README.md) details how to use, test, measure and monitor it.
+
+### Success stories
+Maybe?
+
+#### Adding History syncing to Firefox for iOS and Firefox Preview
+Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus winter purslane kale. Celery potato scallion desert raisin horseradish spinach carrot soko.

--- a/docs/features/firefox-sync/history-feature.md
+++ b/docs/features/firefox-sync/history-feature.md
@@ -13,14 +13,14 @@ sidebar_label: History
 
 ## Fennec History Management
 
-## Mobile Password Management powered by the **Places Component**
+## Mobile History Management powered by the **Places Component**
 - **Component Owner**: Firefox Sync team.
 - **Component Source**: [mozilla/application-services](https://github.com/mozilla/application-services/tree/master/components/places) repository
 
 Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus winter purslane kale. Celery potato scallion desert raisin horseradish spinach carrot soko. Lotus root water spinach fennel kombu maize bamboo shoot green bean swiss chard seakale pumpkin onion chickpea gram corn pea. Brussels sprout coriander water chestnut gourd swiss chard wakame kohlrabi beetroot carrot watercress. Corn amaranth salsify bunya nuts nori azuki bean chick
 
 ### Why should I use the History (places) component?
-Building password management support via the Login component means that a team can have a core shared codebase in Rust, wrapped in native language bindings for supported platforms. Adding password syncing to a browser or browser-like application can be accomplished without having to worry about all the implementation details involved with syncing, storing and encrypting username and password data.
+Building history management support via the Places component means that a team can have a core shared codebase in Rust, wrapped in native language bindings for supported platforms. Adding history syncing to a browser or browser-like application can be accomplished without having to worry about all the implementation details involved with syncing, storing and querying user history data.
 
 ### What features are currently supported?
 - Create, Update and Delete (CRUD) operations for History

--- a/docs/features/firefox-sync/password-management-feature.md
+++ b/docs/features/firefox-sync/password-management-feature.md
@@ -1,0 +1,52 @@
+---
+id: password-management-feature
+title: Password Management
+sidebar_label: Password Management and Syncing
+---
+
+# Password Storage and Syncing
+
+The [Firefox Lockwise](https://lockwise.firefox.com/) product provides users access to their usernames and passwords stored on their Firefox account connected devices and applications so that they can easily sign in to their websites and apps. The Firefox mobile applications and Firefox desktop implementations allow users to save, edit, delete and sync encrypted username and password form data and HTTP authentication credentials.
+
+**Feature owner**: Personal Data Protection team
+
+## Desktop Password Management
+
+### Features
+- Locally encrypted storage of username and password information
+- Create, Update and Delete (CRUD) operations for login data
+- Syncing of logins for devices and apps connected via Firefox Accounts
+- Import functionality from existing login storage such as Firefox (desktop or mobile) and Lockwise
+- Search
+- De-duping
+- Parsing and sanitizing origin data
+- Insecure warnings
+- Form Autofill
+
+## Fennec Password Management
+Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus winter purslane kale. Celery potato scallion desert raisin horseradish spinach carrot soko.
+
+## Mobile Password Management powered by the **Logins Component**
+- **Component Owner**: Firefox Sync team.
+- **Component Source**: [mozilla/application-services](https://github.com/mozilla/application-services/tree/master/components/logins) repository
+
+The **logins component** first reached production users with the implementation in the Lockwise mobile application.   A client application can depend on the logins component to store, modify and optionally sync credentials for the purpose of password management or simplifying web authentication through form autofill.
+
+### Why should I use the logins component?
+Building password management support via the Login component means that a team can have a core shared codebase in Rust, wrapped in native language bindings for supported platforms. Adding password syncing to a browser or browser-like application can be accomplished without having to worry about all the implementation details involved with syncing, storing and encrypting username and password data.
+
+### What features are currently supported?
+- Locally encrypted storage of username and password information
+- Create, Update and Delete (CRUD) operations for login data
+- Syncing of logins for devices and apps connected via Firefox Accounts
+- Import functionality from existing login storage such as Firefox (desktop or mobile) and Lockwise
+- Data migration functionality from Fennec to Firefox Preview storage
+
+### Where can I learn more?
+The [logins component readme](https://github.com/mozilla/application-services/blob/master/components/logins/README.md) details how to use, test, measure and monitor it.
+
+### Success stories
+Maybe?
+
+#### Lockwise for iOS and Android
+Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus winter purslane kale. Celery potato scallion desert raisin horseradish spinach carrot soko.

--- a/docs/features/firefox-sync/sync-feature.md
+++ b/docs/features/firefox-sync/sync-feature.md
@@ -1,0 +1,16 @@
+---
+id: sync-feature
+title: Firefox Synced Data
+sidebar_label: Overview
+---
+
+## What are you syncing about?
+Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus winter purslane kale. Celery potato scallion desert raisin horseradish spinach carrot soko. Lotus root water spinach fennel kombu maize bamboo shoot green bean swiss chard seakale pumpkin onion chickpea gram corn pea. Brussels sprout coriander water chestnut gourd swiss chard wakame kohlrabi beetroot carrot watercress. Corn amaranth salsify bunya nuts nori azuki bean chick
+
+## What can I sync now?
+
+Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus winter purslane kale. Celery potato scallion desert raisin horseradish spinach carrot soko. Lotus root water spinach fennel kombu maize bamboo shoot green bean swiss chard seakale pumpkin onion chickpea gram corn pea. Brussels sprout coriander water chestnut gourd swiss chard wakame kohlrabi beetroot carrot watercress. Corn amaranth salsify bunya nuts nori azuki bean chick
+
+## What if I want to sync some new data type
+
+Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus winter purslane kale. Celery potato scallion desert raisin horseradish spinach carrot soko. Lotus root water spinach fennel kombu maize bamboo shoot green bean swiss chard seakale pumpkin onion chickpea gram corn pea. Brussels sprout coriander water chestnut gourd swiss chard wakame kohlrabi beetroot carrot watercress. Corn amaranth salsify bunya nuts nori azuki bean chick

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -13,7 +13,7 @@
       "features/features",
       {
         "type": "subcategory",
-        "label": "FxA Features",
+        "label": "Firefox Account Management",
         "ids": [
           "features/fxa-details/fxa-features-overview",
           "features/fxa-details/feature-detail-example"
@@ -21,16 +21,19 @@
       },
       {
         "type": "subcategory",
-        "label": "Subscription Platform",
+        "label": "Subscription Management",
         "ids": [
           "features/subscription-platform-details/subscription-platform-features"
         ]
       },
       {
         "type": "subcategory",
-        "label": "Sync Client Integration",
+        "label": "Firefox Sync",
         "ids": [
-          "features/sync-client-integration-details/sync-client-integration-features"
+          "features/firefox-sync/sync-feature",
+          "features/firefox-sync/password-management-feature",
+          "features/firefox-sync/bookmarks-feature",
+          "features/firefox-sync/history-feature"
         ]
       }
     ],


### PR DESCRIPTION
This is a starting point for the Logins component information that should exist as a part of the larger body of work related to logins sync and storage (aka password management).

I've also modified the sidebar structure to refocus on a hierarchy based on features vs teams.

