### PR TITLE
feat: consolidate sync testing docs

### DIFF
--- a/PR_TEMPLATE.md
+++ b/PR_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Description
+
+Describe these changes.
+
+## Testing
+
+How should reviewers test?
+
+## Issue(s)
+
+Closes [link](link).

--- a/docs/about/the-teams.md
+++ b/docs/about/the-teams.md
@@ -1,7 +1,7 @@
 ---
 id: the-teams
 title: The Teams
-sidebar_label: The teams
+sidebar_label: The Teams
 ---
 
 ## Section

--- a/docs/features/firefox-sync/storage-feature.md
+++ b/docs/features/firefox-sync/storage-feature.md
@@ -1,0 +1,24 @@
+---
+id: storage-feature
+title: Storage
+sidebar_label: Storage
+---
+
+## Overview
+Firefox Sync is designed to work with multiple storage options, allowing users to host their own Sync servers in order to connect to self hosted storage options. Currently, Sync storage supports MySQL, SQLite, and Spanner.
+
+The current version of the Sync Storage API is 1.5. 
+
+## Schema
+
+The Sync Storage API defines an HTTP web service used to store and retrieve simple JSON objects called Basic Storage Objects (BSOs), which are organized into named Collections. For more detailed schema information, please refer to the [SyncStorage 1.5 API docs](https://mozilla-services.readthedocs.io/en/latest/storage/apis-1.5.html). 
+
+## MySQL & SQLite
+
+Although Spanner is the database of choice in production, it's not always ideal for testing local changes (or if you want to self-host). We also support MySQL and SQLite, which can be configured [here](https://github.com/mozilla-services/syncserver/blob/master/syncserver.ini#L23) in the syncserver.
+
+## Spanner
+
+Google's [Cloud Spanner](https://cloud.google.com/spanner/) was selected in 2019 as a viable replacement for the existing production MySQL nodes mainly due to it's highly scalable infrastructure. There is one major Spanner-specific tradeoff that has been made within the Sync server logic in order to work with it, which is worth mentioning here:
+
+* We needed to change our `limits.max_total_records` from `10,000` to [`1,666`](https://github.com/mozilla-services/syncstorage-rs/blob/master/spanner_config.ini) due to [this issue](https://github.com/mozilla-services/syncstorage-rs/issues/333) which stems from a Spanner [limitation for mutations per commit](https://cloud.google.com/spanner/quotas). This limits to `20,000 mutation operations`. This number is deceptively smaller than it appears however, due to the [fact that inserts and updates count each column as a single operation](https://cloud.google.com/spanner/quotas#note2).

--- a/docs/process/sync-testing.md
+++ b/docs/process/sync-testing.md
@@ -1,0 +1,139 @@
+---
+id: sync-testing
+title: Sync Testing
+sidebar_label: Sync Testing
+---
+
+## Overview
+Testing Sync is complex; it involves testing multiple possible clients, engines, storage options, all against different environments. Configuring each of these can be time consuming; here's a cheat sheet to help you get up and running.
+
+## Testing Against Specific Environments
+Note: these documents are all geared towards the newer [syncstorage-rs](https://github.com/mozilla-services/syncstorage-rs) project. Until the legacy Sync server is retired, you can find detailed instructions on it's usage [here](https://mozilla-services.readthedocs.io/en/latest/howtos/run-sync-1.5.html).
+
+### Development
+
+#### Desktop
+
+1. Use a production Firefox account.
+2. Now, follow the instructions in the [connecting to Firefox section](https://github.com/mozilla-services/syncstorage-rs#connecting-to-firefox) of the README. It's recommended to test against [MySQL](https://github.com/mozilla-services/syncstorage-rs#mysql), but if you're feeling adventurous, you can also try [Spanner](https://github.com/mozilla-services/syncstorage-rs#spanner).
+
+
+### Staging
+
+#### Desktop
+
+1. First, make sure you're using a [staging Firefox account](/ecosystem-platform/docs/process/using-the-staging-environment#working-with-staging-firefox-accounts).
+2. Now, follow the instructions to [verify setup via a manual Sync](#verify-ive-set-things-up-correctly).
+
+#### iOS
+
+1. Follow the instructions to [point Firefox iOS to staging](/ecosystem-platform/docs/process/using-the-staging-environment#ios).
+2. Now, follow the instructions to [verify setup via a manual Sync](#verify-ive-set-things-up-correctly).
+
+#### Android
+
+This is not currently possible for Fenix. See [using the staging environment](/ecosystem-platform/docs/process/using-the-staging-environment#android) for more details.
+
+## Testing Specific Sync Engines
+
+Sync engines are the term used for types of data that can be Synced. Ie, "bookmarks" is a different engine than "addresses", and so forth.
+
+### Lockwise
+
+Behind the scenes, [Lockwise](https://www.mozilla.org/en-US/firefox/lockwise/) uses Sync to share logins across devices.
+
+#### Desktop
+Testing Lockwise in Desktop against staging follows [the same process as Desktop](/ecosystem-platform/docs/process/using-the-staging-environment#desktop).
+
+
+#### iOS
+Currently, Lockwise iOS requires a custom build to test against a custom Sync server. You can follow the feature request to get this added to the UI [here](https://github.com/mozilla-lockwise/lockwise-android/issues/1129). In the meantime, you'll need to create a local custom build for testing:
+
+1. First, you'll need to [setup Lockwise iOS locally](https://github.com/mozilla-lockwise/lockwise-ios/blob/master/docs/install.md).
+2. Now, open [AccountStore.swift](https://github.com/mozilla-lockwise/lockwise-ios/blob/master/lockbox-ios/Store/AccountStore.swift) and change the [config declaration](https://github.com/mozilla-lockwise/lockwise-ios/blob/master/lockbox-ios/Store/AccountStore.swift#L122) from `FxAConfig.release` to `FxAConfig.dev`. 
+3. Re-build the lockbox scheme in Xcode (Product > Build).
+4. Open the XCode Simulator, and login using an existing [staging Firefox account](/ecosystem-platform/docs/process/using-the-staging-environment#working-with-staging-firefox-accounts).
+5. Test adding a new login on Desktop (pointed to staging) Lockwise.
+6. Now, in the XCode Simulator force a Sync by pulling down on the list of logins.
+
+#### Android
+
+Currently, Lockwise Android requires a custom build to test against a custom Sync server. You can follow the feature request to get this added to the UI [here](https://github.com/mozilla-lockwise/lockwise-ios/issues/1175). In the meantime, you'll need to create a local custom build for testing:
+
+1. First, you'll need to [setup Lockwise for Android locally](https://github.com/mozilla-lockwise/lockwise-android/blob/master/docs/install.md). Make sure to at least open the project in [Android Studio](https://developer.android.com/studio/install) once, which will force it to install the correct dependencies.
+2. Now, open [AccountStore.kt](https://github.com/mozilla-lockwise/lockwise-android/blob/master/app/src/main/java/mozilla/lockbox/store/AccountStore.kt) and change the [config declaration](https://github.com/mozilla-lockwise/lockwise-android/blob/master/app/src/main/java/mozilla/lockbox/store/AccountStore.kt#L269) from `ServerConfig.release` to `ServerConfig.dev`.
+3. Rebuild the project in Android Studio (Build > Make Project).
+4. Now, open the [Android Virtual Device Manager](https://developer.android.com/studio/run/managing-avds) within Android Studio, and make sure you have a device downloaded.
+5. Open your device in the [Android Studio Emulator](https://developer.android.com/studio/run/emulator), and login using an existing [staging Firefox account](/ecosystem-platform/docs/process/using-the-staging-environment#working-with-staging-firefox-accounts). If you've previously logged in using this virtual device while pointed to production, you may need to download a new device to bypass auth caching.
+
+
+## How do I...
+
+## ...find my Sync id?
+
+Each Firefox account has a unique Sync id associated with it. There's a few different ways to find it:
+
+#### via the Browser Console:
+
+1. First, make sure that the Browser Console (different than Developer Tools Console) is enabled. Open the [Developer Tools Settings](https://developer.mozilla.org/en-US/docs/Tools/Settings) (Desktop menu: Tools > Web Developer > Toggle Tools > “…” > Settings), and check the “Enable browser chrome and add-on debugging toolboxes” setting in the “Advanced settings” section.
+
+2. In `about:config`, set `devtools.chrome.enabled` to `true`. This will allow you to type into the Browser Console.
+
+3. Now, manually Sync (Account Menu > Sync Now).
+
+4. Open the Browser Console (Tools > Web Developer > Browser Console) and type `Weave.Service.clusterURL`. 
+
+   You should see something similar to `https://sync-3-us-east-1.stage.mozaws.net/1.5/0000000/`, where `0000000` corresponds to your Sync Id.
+
+#### via Sync Logs:
+
+1. First, verify that you've configured your Sync logs to [log successful Syncs](#configure-sync-logging).
+
+2. Now, manually Sync (Account Menu > Sync Now).
+
+3. Now, [browse to your Sync logs](#configure-sync-logging), and open the most recent one. Scan through it for something that looks like this: `POST success 200 https://sync-3-us-east-1.stage.mozaws.net/1.5/0000000/storage/tabs?batch=true&commit=true`. The `0000000` will correspond to your Sync Id.
+
+
+## ...verify I've set things up correctly?
+
+1. In Desktop, manually Sync (Account Menu > Sync Now).
+2. Open your [Sync logs](#configure-sync-logging) to verify that you're syncing to the correct host. Sometimes, you'll need to restart Firefox after making a change to the Sync host in order for your new host to register correctly. Scan through the logs for something that looks like this: 
+     `POST success 200 https://sync-3-us-east-1.stage.mozaws.net/1.5/0000000/storage/tabs?batch=true&commit=true.`
+
+    * For **production**, your sync host will look like this:
+        
+        * `sync-<id-number>-<gcp-region>-g.sync.services.mozilla.com` ie, `https://sync-1-us-east-1.sync.services.mozilla.com` (GCP)
+        * `sync-<id-number>-<aws-region>.sync.service.mozilla.com` ie, `https://sync-1-us-west1-g.sync.services.mozilla.com` (AWS - Legacy) 
+    * For **staging**, your sync host will look like this: 
+    
+      * `https://stage.sync.nonprod.cloudops.mozgcp.net` (GCP)
+      * `https://sync-3-us-east-1.stage.mozaws.net` (AWS - Legacy)
+    * For **development**, you should see `localhost:PORT` for your sync host.
+
+## ...configure Sync logging?
+
+Open `about:sync-log` to see all your Sync logs.
+
+#### log output for successful Syncs:
+
+By default, sync logs are setup to log only errors. You can force successful syncs to output log info as well by:
+
+1. Open `about:config`.
+2. Set `services.sync.log.appender.file.logOnSuccess` to `true`.
+
+#### enable trace logging:
+
+1. First, download and install the [about-sync](https://addons.mozilla.org/en-US/firefox/addon/about-sync/) add-on.
+2. Then, open `about:sync` and from the "General Options" menu, select `Actively looking for issues and want detailed logging`.
+
+## ...get access to Spanner?
+
+This is currently a manual process. Contact <a href="mailto:servicesengineering@mozilla.com">services engineering</a> for more information.
+
+## ...know if my Firefox account is pointed to Spanner?
+
+1. Follow the instructions to get your [Sync host](#verify-ive-set-things-up-correctly) above, and then paste it into a browser followed by `__version__`, ie: `https://sync-3-us-east-1.stage.mozaws.net/__version__`. If you see a `0`, you're using MySQL. If you see more detailed JSON including a `source` value of `https://github.com/mozilla-services/syncstorage-rs`, you're pointed to Spanner.
+
+## ...disable caching for auth creds for Sync?
+
+This can be useful if you're making changes to auth servers while testing Sync. There's a flag called `services.sync.debug.ignoreCachedAuthCredentials` that you can set to `true`.

--- a/docs/process/using-the-staging-environment.md
+++ b/docs/process/using-the-staging-environment.md
@@ -1,0 +1,43 @@
+---
+id: using-the-staging-environment
+title: Using the Staging Environment
+sidebar_label: Using the Staging Environment
+---
+
+## Overview
+Staging is available in order to test against an environment that more closely mirrors production. Here is where you can access production-like logs, perform load tests, and work with various Firefox clients that can be more difficult to configure locally.
+
+
+## Working with Staging Firefox Accounts
+
+The first thing you'll need to do is create a Firefox account while pointed at the staging environment. It's easiest to do this in Desktop:
+
+### Desktop
+
+1. First, make sure you are [using a new profile](/ecosystem-platform/docs/process/using-the-staging-environment#create-a-new-firefox-profile).
+2. Now, in `about:config`, set `identity.fxaccounts.autoconfig.uri` to `https://accounts.stage.mozaws.net`.
+3. Restart Firefox. Make sure to use the same profile you setup in step #1.
+4. Now, either login to an existing staging Firefox account, OR create a new Firefox account now that you're pointed to staging.
+5. Once you're logged into your Firefox account, verify that you're actually pointed to staging by [testing a manual Sync](/ecosystem-platform/docs/process/sync-testing#verify-ive-set-things-up-correctly).
+
+### iOS
+
+1. First, delete and then re-install the Firefox iOS app to ensure you're using a fresh profile.
+2. Before logging in, go to Accounts Menu > Settings. Scroll to the bottom, and tap the version number 5 times. You should now see some hidden menu options appear.
+3. Scroll back up to the top of the Settings screen, and select `Debug: use stage servers`.
+4. Then, `Sign in to Sync`. Make sure you're using either an existing staging account, or create a fresh one now that you're pointed to staging.
+5. Once you're logged into your Firefox account, verify that you're actually pointed to staging by [testing a manual Sync](/ecosystem-platform/docs/process/sync-testing#verify-ive-set-things-up-correctly).
+
+### Android
+
+#### Fenix
+
+At the time of this writing, Fenix is the codename for the upcoming Firefox for Android client. On Google's Play Store, it's called [Firefox Preview](https://play.google.com/store/apps/details?id=org.mozilla.fenix&hl=en_US). It's not currently possible to test Fenix against staging FxA servers, however there is an issue open to implement this [here](https://github.com/mozilla-mobile/android-components/issues/3729).
+
+## How do I...
+
+## ...create a new Firefox Profile?
+
+Follow the instructions [here](https://support.mozilla.org/en-US/kb/profile-manager-create-remove-switch-firefox-profiles) for managing your profiles. It can be very useful to set a shortcut to open the profile picker when testing Sync.
+
+* `alias ff_profiles='/Applications/Firefox.app/Contents/MacOS/firefox-bin -P -no-remote'` - an example of a bash alias you could use to start Firefox with the profile picker on OSX.

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -9,7 +9,7 @@ const Index = (props) => {
     <div className="index-message">
         <div className="content-block">
         <h1>Welcome to our docs</h1>
-        <p>This is very early-stage documentation hub for Firefox Accounts, Synced Client Integrations, and Subscription Platform.</p>
+        <p>This is very early-stage documentation hub for Firefox Accounts, Services, Synced Client Integrations, and Subscription Platform.</p>
         <p>The intent of this site is to allow members of these teams to build up documentation without having to overwrite existing docs.</p>
         <p>This site is built using <a href="https://docusaurus.io/en/">Docusaurus</a>.</p>
         <br></br>

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -4,7 +4,9 @@
     "The Process": [
       "process/integration-with-fxa",
       "process/integration-with-subscription-platform",
-      "process/becoming-a-sync-client"
+      "process/becoming-a-sync-client",
+      "process/sync-testing",
+      "process/using-the-staging-environment"
     ],
     "Platform Features": [
       "features/features",
@@ -30,6 +32,7 @@
           "features/firefox-sync/sync-feature",
           "features/firefox-sync/password-management-feature",
           "features/firefox-sync/bookmarks-feature",
+          "features/firefox-sync/storage-feature",
           "features/firefox-sync/history-feature"
         ]
       }


### PR DESCRIPTION
## Description

We have [a goal this quarter](https://docs.google.com/spreadsheets/d/1RjDzgs-CMuqRD5K18SbkD__RwgBiDcgmLiCqjwTbjOU/edit#gid=21744728) to make Sync more easily testable against staging.

This is step one; start moving some of our existing docs over here. I plan to continue this work throughout the quarter. This effort specifically involves getting the contents of [this doc](https://docs.google.com/document/d/1KnFdE1ee-yv8En5QaPoRj3x2s9kTESoW0lGNh2LwIrI/edit#heading=h.m5439epyhnxm) moved over.

For reference, the meta issue tracking this work lives [here](https://github.com/mozilla-services/services-engineering/issues/29).

## Testing

Read along :) Anything that should be moved or changed?

## Issue(s)

Closes [mozilla-services/services-engineering #25](https://github.com/mozilla-services/services-engineering/issues/25).
