### PR TITLE
feat: add DocSearch as recommended by docusaurus

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -9,6 +9,10 @@
 // site configuration options.
 
 const siteConfig = {
+  algolia: {
+    apiKey: 'bf6d9655ef3d5789d97465aff250ee76',
+    indexName: 'mozilla_ecosystem-platform',
+  },
   title: 'Firefox Ecosystem Platform', // Title for your website.
   tagline: 'Documentation for Firefox Accounts, Sync and more',
   url: 'https://mozilla.github.io', // Your website URL


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.

resolves #26