### PR TITLE
Reorganize metrics docs

### DIFF
--- a/docs/explanation/metrics.md
+++ b/docs/explanation/metrics.md
@@ -1,0 +1,107 @@
+---
+title: Metrics
+---
+
+Last updated: `March 21st, 2022`
+
+Please read our [metrics reference](../reference/metrics) before this document as it has the context of our current system in it.  The document below is about *application metrics*.
+
+
+# A brief history
+The FxA metrics ecosystem is arcane and esoteric, so a brief history of how we got to where we are may be helpful to understand the landscape.
+
+In the beginning there were simple *activity events*. These were basic events emitted from the auth and oauth servers, visualised via now defunct dashboards.
+
+They provided useful insights from a high level about things like how many sign-ins and sign-ups there were. But they didn’t allow us to follow a user’s journey through a sign-in or sign-up flow, which include email verification steps that may take place across multiple devices.
+
+So the *flow events* were created, stored in Redshift and visualised in Redash (and the existing activity metrics were moved to Redshift/Redash at the same time).
+
+Flow events include two extra pieces of metadata, a flow id and a flow begin-time, which gave us more detailed insight into user behaviour. And, unlike the activity events, these were also emitted by client-side code in the content server.
+
+The flow events proved handy for some use-cases that they weren’t meant for, so we started piggy-backing other things like performance metrics, post-sign-in activity and email events on them too. That stressed the infrastructure somewhat, but also gave us the ability to e.g. directly link perf metrics to user behaviour, which was an unexpected new superpower.
+
+The stressed infrastructure meant queries ran pretty slowly though and they required SQL knowledge. And the organic growth of the event schema meant there were issues around inconsistent nomenclature confusing people. And they were ingested via Heka, which meant working with an unfamiliar language (Lua) in an environment that was hard to meaningfully test without just pushing your changes and seeing whether they worked. And we never got round to ingesting the events more frequently than daily, so people were frustrated about having to wait a day to see stuff show up in charts.
+
+For all of those reasons, at the end of 2017 Amplitude was chosen as a paid-for replacement for the more producty metrics we were sending to Redshift.  We called these *Amplitude Events*.
+
+These had some really good properties:
+* The event schema was designed in advance, so it would be less confusing
+* We sent these events in real time.  This was a huge improvement over the 24hr+ lag we were used to
+* Nobody had to wrestle with SQL any more
+
+They also had some really bad properties:
+* The Amplitude service is expensive and we send a lot of events
+* Due to #1, we decided to only send a subset of events.  This means there were now two places you have to look if you don't know exactly what you need.
+
+In June 2020 we stopped using Amplitude due to cost.  That leaves us with a lot of things referring to *amplitude events* still.  That's fine for identifying that subset of events, but understand we don't actually use Amplitude anymore.
+
+## So, where does that leave us?
+
+Well, it's a bit complicated and you should make sure you've read our [metrics reference](../reference/metrics) first.
+
+In the `firefox_accounts` dataset in the `mozdata` project:
+
+* `fxa_[server]_*` tables will be most of the amplitude events
+* `fxa_log_[server]_*` tables will be most of the flow events
+
+However, there are a bunch of other tables in there as well.  In short, only experience can really help you find the data you are looking for if there isn't already a dashboard for it.  Ask the FxA team or #data-help in slack.
+
+# How are metrics emitted?
+
+## Auth server
+
+Activity events, flow events and amplitude events are all just mozlog-format log lines. There are functions for each of them in the module `lib/log.js`, respectively called `activityEvent`, `flowEvent` and `amplitudeEvent`. However, to reduce boilerplate in the codebase they’re actually invoked via calls to `request.emitMetricsEvent`. That function is defined in `lib/metrics/events.js` and is decorated onto the request object by some code in `lib/server.js`.
+
+Activity events must have a `uid` property. Some call sites also set `device_id`. Properties containing user agent information and the OAuth client id are set automatically based on the request object.
+
+Flow events have their properties set automatically too, either from the request object or, if there is an authentication token of some kind, from data stored against the uid and token id in memcached. This data is widely referred to as `metricsContext` throughout the codebase and has a lifetime of 2 hours, which is kind of an arbitrary limit that allows us to fetch data for most flows while ignoring dubious data from stale or non-authentic sources. The `metricsContext` is written to memcached via calls to `request.stashMetricsContext` (where it’s copied from the request data) and `request.propagateMetricsContext` (where it’s copied from some other stashed data). Those functions are both defined in `lib/metrics/context.js` and decorated onto the request object in `lib/server.js`.
+
+Amplitude events are not explicitly emitted (note the exception in [fxa-payments-server](#payments-server)), because they can all be mapped to from previously-existing activity or flow events. Those mappings are defined by structures called `EVENTS` and `FUZZY_EVENTS` in `lib/metrics/amplitude.js`. Any event matching a string key from `EVENTS` or a regex key from `FUZZY_EVENTS` gets transformed into the corresponding event by common code in the `fxa-shared` package (it’s also used by the content server). Most of the properties on those events are set automatically, although there are still some cases where data must be set explicitly at the call site.
+
+StatsD is used to capture latency performance metrics on SQS calls, SNS calls, Stripe calls, and any HTTP API requests handled by `lib/backendService.js` (e.g. requests to our customs server).  It is also used to time the server's request handling on all routes.
+
+## Content server
+
+Again, flow events and amplitude events in the content server are just mozlog-format log lines. But before they can be logged on the back-end, the front-end has to submit them to the endpoint POST `/metrics` first. This is handled by the module `app/scripts/lib/metrics.js`.
+
+The front-end also needs to make sure it has a `flowId` and `flowBeginTime`, either from `data- attributes` on the body element that were set by the back-end, or from data propagated in the resume token. In both cases, the data is loaded by `app/scripts/models/flow.js`.
+
+After they reach the back-end, events are processed by `server/lib/flow-event.js`. And, just like the auth server, there are `EVENTS` and `FUZZY_EVENTS` mappings to control transformations to amplitude events in `server/lib/amplitude.js`.
+
+## Event Broker
+
+StatsD is used to collect SQS processing latency metrics and message type counts.  Details are on [the package's README][event-broker-readme].
+
+## Payments server
+
+One thing to keep in mind is that users should not access the pages on Payments directly.  The Content server will redirect them to the Payments server, along with metrics related query params.  Those query params are:
+
+- `flow_id`
+- `flow_begin_time`
+- `device_id`
+
+They are converted to `camelCase` once in Payments.
+
+The main module on the front end for emitting events is `src/lib/flow-events.ts`.  Its `init` function is called in `src/App.tsx`, during which the three query params above are passed into the module.
+
+A call to `logAmplitudeEvent` results in a `POST` to `/metrics`, which is handled by `server/lib/routes/post-metrics.js`.  The events are log lines in identitical formats to those emitted by Content server.
+
+The Payments frontend reports the timing data surfaced by [Navigation Timing Level 2][navigation-timing-2] back to the server side, which then sends the calculated performance metrics to our statsD server.  One major difference between these performance metrics and those in Redshift for Content Server is that these do not have a flow id to connect the timings into a performance overview for a particular request.
+
+## Relying Parties
+
+See [metrics for relying parties][rp-metrics].
+
+# What other docs are there?
+
+:::caution
+These are pretty old and may not be accurate
+:::
+
+* https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/metrics-events.md
+* https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/docs/client-metrics.md
+
+[redux-actions]: https://redux.js.org/basics/actions
+[event-broker-readme]: https://github.com/mozilla/fxa/tree/main/packages/fxa-event-broker#metrics
+[navigation-timing-2]: https://www.w3.org/TR/navigation-timing-2/
+[rp-metrics]: ../relying-parties/metrics-for-relying-parties.md

--- a/docs/how-tos/working-with-metrics.md
+++ b/docs/how-tos/working-with-metrics.md
@@ -1,0 +1,42 @@
+---
+title: Working with Metrics
+---
+
+Last updated: `March 21st, 2022`
+
+Other relevant documents include our [metrics reference](../reference/metrics) and [metrics explanation](../explanation/metrics).
+
+# How do I...
+
+## ...create a new activity event?
+
+0. Add the event name to `ACTIVITY_EVENTS` in `lib/metrics/events.js`. Unless it’s also a flow event (most new events will be one or the other), you should also add it to `NOT_FLOW_EVENTS` in the same module.
+0. Emit the new event in code like `request.emitMetricsEvent('foo.bar', { uid })`.
+0. Wherever you emit it, add test cases to cover that the event is correctly logged.
+
+## ...create a new flow event?
+
+### Auth server
+0. Emit the new event in code like `request.emitMetricsEvent('foo.bar')`.
+0. Wherever you emit it, add test cases to cover that the event is correctly logged.
+0. Be aware that flow events are only emitted if you have a `metricsContext`. If there’s one in the payload for the current route, you’re all good. If not, the code will try to read one from memcached for you. But a previous call to `request.stashMetricsContext` or `request.propagateMetricsContext` will need to have been made with the token that your request is authenticated by. Maybe that’s done already, maybe it isn’t, you’ll need to trace the request flow and grep the code.
+
+### Content server
+0. On the front-end, make sure your view has mixed in `FlowEventsMixin`.
+0. view and engage events will be emitted automatically when you add the mixin, for other events you need to call `this.logFlowEvent` from your view.
+0. Add test coverage for the new event to your view unit tests.
+
+## ...create a new email event?
+You don’t need to do this, it’s all set up to work automatically.
+
+## ...create a new Amplitude event?
+
+### Auth server
+0. Amplitude events are all triggered by activity or flow events, so the first step is to ensure there’s one of those (see above if you need to create a new one).
+0. If you’re triggering from a specific event, add a new mapping to the `EVENTS` object in `lib/metrics/amplitude.js`. If you’re triggering from a set of events, add a mapping to `FUZZY_EVENTS` instead.
+0. Add a new test case for the new event to `test/local/metrics/amplitude.js`. Every event should have its own test case in that module.
+
+### Content server
+0. Amplitude events are all triggered by flow or screen events, so the first step is to ensure there’s one of those (see above if you need to create a new flow event).
+0. If you’re triggering from a specific event, add a new mapping to the `EVENTS` object in `server/lib/amplitude.js`. If you’re triggering from a set of events, add a mapping to `FUZZY_EVENTS` instead.
+0. Add a new test case for the new event to `tests/server/amplitude.js`. Every event should have its own test case in that module.

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -2,196 +2,70 @@
 title: Metrics
 ---
 
-Last updated: `March 11th, 2020`
+Last updated: `March 21st, 2022`
+
+Firefox accounts collects metrics from servers running our code and clients accessing our services.  Mozilla takes data collection seriously so our policies and processes around it may seem more complex than most organizations but it is in an effort to grant agency to users over their own data.
+
+Note that the [Mozilla Data Collection policies](https://wiki.mozilla.org/Data_Collection) apply to Firefox Accounts.
+
+Our code is deployed to a staging environment before it goes to production so the metrics detailed below are available for both environments.  The details below will focus mostly on production.
+
+Keep in mind that Firefox accounts allows users to opt-out of data collection via a toggle on the account settings page.
+
+We also have a [metrics section which expands on the history of our system and how these are implemented](../explanation/metrics).
+
+# Application metrics
 
 :::caution
-This is a bit outdated.  We no longer use Amplitude.
+Derived tables do not include all the events in the original logs.  You can read the queries that create the derived tables to see what is included.
 :::
 
-# What types of metrics are there?
-The FxA metrics ecosystem is somewhat arcane and esoteric, so a brief history of how we got to where we are may be helpful to understand the landscape.
-
-In the beginning there were activity events. These were basic events emitted from the auth and oauth (and profile?) servers, visualised via the now-defunct accounts dashboard:
-
-* https://metrics.services.mozilla.com/accounts-dashboard/
-* https://github.com/mozilla/accounts-dashboard
-
-They provided useful insights from a high level about things like how many sign-ins and sign-ups there were. But they didn’t allow us to follow a user’s journey through a sign-in or sign-up flow, which include email verification steps that may take place across multiple devices.
-
-So the flow events were created, stored in Redshift and visualised in Redash (and the existing activity metrics were moved to Redshift/Redash at the same time):
-
-* https://sql.telemetry.mozilla.org/
-* https://github.com/mozilla/fxa-activity-metrics/
-
-Flow events include two extra pieces of metadata, a flow id and a flow begin-time, which gave us more detailed insight into user behaviour. And, unlike the activity events, these were also emitted by client-side code in the content server.
-
-The flow events proved handy for some use-cases that they weren’t meant for, so we started piggy-backing other things like performance metrics, post-sign-in activity and email events on them too. That stressed the infrastructure somewhat, but also gave us the ability to e.g. directly link perf metrics to user behaviour, which was an unexpected new superpower.
-
-The stressed infrastructure meant queries ran pretty slowly though and they required SQL knowledge. And the organic growth of the event schema meant there were issues around inconsistent nomenclature confusing people. And they were ingested via Heka, which meant working with an unfamiliar language (Lua) in an environment that was hard to meaningfully test without just pushing your changes and seeing whether they worked. And we never got round to ingesting the events more frequently than daily, so people were frustrated about having to wait a day to see stuff show up in charts.
-
-For all of those reasons, Amplitude was chosen as a paid-for replacement for the more producty metrics we were sending to Redshift:
-
-* https://analytics.amplitude.com/org/31251
-* https://github.com/mozilla/fxa-amplitude-send
-
-The event schema was designed in advance, so it would be less confusing to understand and we sent them to Amplitude in real time from the very beginning, so there was no inertia around making them show up instantly in the UI. And nobody needed to wrestle with SQL any more.
-
-But the limited event schema we have in Amplitude means there are some things we can’t see there, so the stuff in Redshift+Redash remains a useful resource, especially for devs.
-
-In Fall of 2019, FxA started sending [StatsD][statsd-origin] metrics to Mozilla's [InfluxDB][influxdb-mana] stack.  These are performance metrics.  They powered our dashboards in [Grafana][grafana-dashboards].  At the time of writing, the FxA packages that use StatsD include:
- - fxa-auth-server
- - fxa-event-broker
- - fxa-payments-server
-
-# How are metrics emitted?
-
-## Auth server
-
-Activity events, flow events and amplitude events are all just mozlog-format log lines. There are functions for each of them in the module `lib/log.js`, respectively called `activityEvent`, `flowEvent` and `amplitudeEvent`. However, to reduce boilerplate in the codebase they’re actually invoked via calls to `request.emitMetricsEvent`. That function is defined in `lib/metrics/events.js` and is decorated onto the request object by some code in `lib/server.js`.
-
-Activity events must have a `uid` property. Some call sites also set `device_id`. Properties containing user agent information and the OAuth client id are set automatically based on the request object.
-
-Flow events have their properties set automatically too, either from the request object or, if there is an authentication token of some kind, from data stored against the uid and token id in memcached. This data is widely referred to as `metricsContext` throughout the codebase and has a lifetime of 2 hours, which is kind of an arbitrary limit that allows us to fetch data for most flows while ignoring dubious data from stale or non-authentic sources. The `metricsContext` is written to memcached via calls to `request.stashMetricsContext` (where it’s copied from the request data) and `request.propagateMetricsContext` (where it’s copied from some other stashed data). Those functions are both defined in `lib/metrics/context.js` and decorated onto the request object in `lib/server.js`.
-
-Amplitude events are not explicitly emitted, because they can all be mapped to from previously-existing activity or flow events. Those mappings are defined by structures called `EVENTS` and `FUZZY_EVENTS` in `lib/metrics/amplitude.js`. Any event matching a string key from `EVENTS` or a regex key from `FUZZY_EVENTS` gets transformed into the corresponding event by common code in the `fxa-shared` package (it’s also used by the content server). Most of the properties on those events are set automatically, although there are still some cases where data must be set explicitly at the call site.
-
-StatsD is used to capture latency performance metrics on SQS calls, SNS calls, Stripe calls, and any HTTP API requests handled by `lib/backendService.js` (e.g. requests to our customs server).  It is also used to time the server's request handling on all routes.
-
-## Content server
-
-Again, flow events and amplitude events in the content server are just mozlog-format log lines. But before they can be logged on the back-end, the front-end has to submit them to the endpoint POST `/metrics` first. This is handled by the module `app/scripts/lib/metrics.js`.
-
-The front-end also needs to make sure it has a `flowId` and `flowBeginTime`, either from `data- attributes` on the body element that were set by the back-end, or from data propagated in the resume token. In both cases, the data is loaded by `app/scripts/models/flow.js`.
-
-After they reach the back-end, events are processed by `server/lib/flow-event.js`. And, just like the auth server, there are `EVENTS` and `FUZZY_EVENTS` mappings to control transformations to amplitude events in `server/lib/amplitude.js`.
-
-## Event Broker
-
-StatsD is used to collect SQS processing latency metrics and message type counts.  Details are on [the package's README][event-broker-readme].
-
-## Payments server
-
-One thing to keep in mind is that users should not access the pages on Payments directly.  The Content server will redirect them to the Payments server, along with metrics related query params.  Those query params are:
-
-- `flow_id`
-- `flow_begin_time`
-- `device_id`
-
-They are converted to `camelCase` once in Payments.
-
-The main module on the front end for emitting events is `src/lib/flow-events.ts`.  Its `init` function is called in `src/App.tsx`, during which the three query params above are passed into the module.
-
-_All_ Amplitude events are emitted from `src/store/amplitude-middleware.ts`.  They are triggered by [Redux actions][redux-actions].
-
-A call to `logAmplitudeEvent` results in a `POST` to `/metrics`, which is handled by `server/lib/routes/post-metrics.js`.  The events are log lines in identitical formats to those emitted by Content server.
-
-The Payments frontend reports the timing data surfaced by [Navigation Timing Level 2][navigation-timing-2] back to the server side, which then sends the calculated performance metrics to our statsD server.  One major difference between these performance metrics and those in Redshift for Content Server is that these do not have a flow id to connect the timings into a performance overview for a particular request.
-
-## Relying Parties
-
-See [metrics for relying parties][rp-metrics].
-
-# How are metrics ingested?
-
-## Redshift
-
-Activity and flow events are one of the last remaining datasets that is still being processed by our old Heka-based data pipeline. The data pipeline team are keen to migrate us away from there asap, but so far it didn’t happen yet. It would also benefit us to migrate away, since fear of breaking the Heka filter has discouraged us from making changes to the flow event schema in the past.
-
-The Heka filter does some processing on the events and then writes them once-per-day to CSV files stored in S3 buckets:
-
-* s3://net-mozaws-prod-us-west-2-pipeline-analysis/fxa-retention/data/events/* (activity events)
-* s3://net-mozaws-prod-us-west-2-pipeline-analysis/fxa-flow/data/* (flow events)
-* s3://net-mozaws-prod-us-west-2-pipeline-analysis/fxa-email/data/email-events/* (email events, which can be thought of as a variation of the flow events emitted by email-handling code in the auth server)
-
-The CSV files are then processed by python scripts in the `mozilla/fxa-activity-metrics` repo, running on the fxa-admin EC2 instance (managed by jrgm and jbuck):
-
-* https://github.com/mozilla/fxa-activity-metrics/
-* https://github.com/mozilla-services/cloudops-deployment/blob/master/projects/fxa/puppet/modules/fxa_admin/manifests/init.pp
-
-The scripts import the data to a Redshift cluster managed by Ops, then expire old data.
-
-For activity events, the table names are:
-
-* activity_events
-* daily_activity_per_device
-* daily_multi_device_users
-
-For flow events, the table names are:
-
-* flow_events
-* flow_metadata
-
-For email events, the table names are:
-
-* email_events
-
-All of the tables named above contain a rolling 3-month window of data, to keep query times reasonable. We also maintain sampled datasets that have longer windows. Those are suffixed with `*_sampled_50` for the 50%-sampled dataset, which has a 6-month rolling window, and `*_sampled_10` for the 10%-dataset, which has a 2-year rolling window.
-
-The tables are visible in Redash, under the “FxA Activity Metrics” data source.
-
-## Amplitude
-
-Our Amplitude events are sent to a GCP pubsub queue from stackdriver, this stuff is managed by jbuck. We have a node script that listens to the queue and then sends the events to Amplitude:
-
-* https://github.com/mozilla/fxa-amplitude-send
-
-We manage to avoid any of the complicated batching logic recommended by some of the Amplitude documentation because our device ids for Amplitude are not persistent, they’re randomly-generated on every page load. So we don’t fall foul of the rate limits, except occasionally if there is some automated testing that thrashes a load of events in quick succession. There are issues open in the fxa repo about the device id thing, it was supposed to be a temporary measure but it’s been like that for years now so…
-
-We do split some of the Amplitude metrics out to the [Identify API][amplitude-identify-api] so we can use its $append syntax. But most stuff just goes in to the plain [HTTP API][amplitude-http-api].
-
-## InfluxDB
-
-The statsD metrics are sent to Telegraf, which then batch writes to InfluxDB.  The FxA team does not manage any part of the InfluxDB stack.
-
-# How do I...
-
-## ...create a new activity event?
-
-0. Add the event name to `ACTIVITY_EVENTS` in `lib/metrics/events.js`. Unless it’s also a flow event (most new events will be one or the other), you should also add it to `NOT_FLOW_EVENTS` in the same module.
-0. Emit the new event in code like `request.emitMetricsEvent('foo.bar', { uid })`.
-0. Wherever you emit it, add test cases to cover that the event is correctly logged.
-
-## ...create a new flow event?
-
-### Auth server
-0. Emit the new event in code like `request.emitMetricsEvent('foo.bar')`.
-0. Wherever you emit it, add test cases to cover that the event is correctly logged.
-0. Be aware that flow events are only emitted if you have a `metricsContext`. If there’s one in the payload for the current route, you’re all good. If not, the code will try to read one from memcached for you. But a previous call to `request.stashMetricsContext` or `request.propagateMetricsContext` will need to have been made with the token that your request is authenticated by. Maybe that’s done already, maybe it isn’t, you’ll need to trace the request flow and grep the code.
-
-### Content server
-0. On the front-end, make sure your view has mixed in `FlowEventsMixin`.
-0. view and engage events will be emitted automatically when you add the mixin, for other events you need to call `this.logFlowEvent` from your view.
-0. Add test coverage for the new event to your view unit tests.
-
-## ...create a new email event?
-You don’t need to do this, it’s all set up to work automatically.
-
-## ...create a new Amplitude event?
-0. The first step is to make sure it’s been approved by Alex or Leif, because the Amplitude schema is tightly controlled and we pay per event.
-
-### Auth server
-0. Amplitude events are all triggered by activity or flow events, so the first step is to ensure there’s one of those (see above if you need to create a new one).
-0. If you’re triggering from a specific event, add a new mapping to the `EVENTS` object in `lib/metrics/amplitude.js`. If you’re triggering from a set of events, add a mapping to `FUZZY_EVENTS` instead.
-0. Add a new test case for the new event to `test/local/metrics/amplitude.js`. Every event should have its own test case in that module.
-
-### Content server
-0. Amplitude events are all triggered by flow or screen events, so the first step is to ensure there’s one of those (see above if you need to create a new flow event).
-0. If you’re triggering from a specific event, add a new mapping to the `EVENTS` object in `server/lib/amplitude.js`. If you’re triggering from a set of events, add a mapping to `FUZZY_EVENTS` instead.
-0. Add a new test case for the new event to `tests/server/amplitude.js`. Every event should have its own test case in that module.
-
-# What other docs are there?
-* https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/metrics-events.md
-* https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/docs/client-metrics.md
-* https://github.com/mozilla/application-services/blob/main/docs/metrics
-
-
-
-[amplitude-http-api]: https://help.amplitude.com/hc/en-us/articles/204771828-HTTP-API
-[amplitude-identify-api]: https://help.amplitude.com/hc/en-us/articles/205406617-Identify-API-Modify-User-Properties
-[redux-actions]: https://redux.js.org/basics/actions
-[statsd-origin]: https://codeascraft.com/2011/02/15/measure-anything-measure-everything/
-[influxdb-mana]: https://mana.mozilla.org/wiki/pages/viewpage.action?spaceKey=SVCOPS&title=InfluxDB
-[grafana-dashboards]: https://earthangel-b40313e5.influxcloud.net/dashboards/f/Q6zOs-JZk/firefox-accounts-fxa
-[event-broker-readme]: https://github.com/mozilla/fxa/tree/main/packages/fxa-event-broker#metrics
-[navigation-timing-2]: https://www.w3.org/TR/navigation-timing-2/
-[rp-metrics]: ../relying-parties/metrics-for-relying-parties.md
+These are logs from Firefox accounts code.  These are probably the most useful logs for product decision making as they were written by hand by engineers.  They are also the most comlex.
+
+* Example data recorded
+  * See the [taxonomies in the Mozilla Data Docs](https://docs.telemetry.mozilla.org/datasets/fxa.html).
+* Recorded with
+  * These are logged via [mozlog](https://github.com/mozilla/mozlog/) as regular server logs.
+  * The logs are immediately ingested into [GCP Cloud Logging](https://cloud.google.com/logging)
+  * From there they are passed and stored in BigQuery in the `fxa-prod` or `fxa-nonprod` projects depending on which environment they are coming out of.  These projects are relatively restricted and not for general consumption.
+  * Every 24 hours, [some ETL jobs](https://github.com/mozilla/bigquery-etl/tree/main/sql/moz-fx-data-shared-prod/firefox_accounts_derived) run which create derived tables from the original logs and store them in the `mozdata` project in BigQuery.  `mozdata` is accessible by anyone at Mozilla.
+  * Additionally, there are some [user-facing datasets](https://github.com/mozilla/bigquery-etl/tree/main/sql/moz-fx-data-shared-prod/firefox_accounts) of that same data, and also in `mozdata`, which are designed to be easier to use.
+* Accessible via
+  * [BigQuery](https://console.cloud.google.com/bigquery?).  Look for the `firefox_accounts` dataset in the `mozdata` project.  *Be aware that there are large amounts of data in BigQuery and you can spend a lot of money if you don't restrict your queries.*
+  * Looker is backed by BigQuery and there is a [Firefox Accounts folder](https://mozilla.cloud.looker.com/folders/374) there
+  * There are [several dashboards in grafana](https://earthangel-b40313e5.influxcloud.net/?orgId=1&search=open&query=fxa) with a mix of these metrics on them
+  * 
+
+:::note
+If you need real-time data you need to be looking at the raw logs in `fxa-prod`.  Otherwise there will be a 24 hour delay on the data.  We don't run our normal metrics out of those logs because it is too expensive and slow.
+:::
+
+# Crashes
+
+* Example data recorded:
+  * `t is undefined` and a link to the JS that failed to run
+  * `An internal validation check failed.` and details about what the software expected to see and what it actually saw
+* Recorded with
+  * Sentry
+* Accessible via
+  * [Sentry](https://sentry.prod.mozaws.net/operations/)
+  * Look for any project starting with `fxa-`.  Eg. `fxa-auth-prod` and `fxa-content-client-prod`
+
+# Server Health
+
+* Example data recorded
+  * There are 30 healthy hosts running
+  * A host is running at 100% cpu
+* Recorded with
+  * The reporting tools built into the clouds we use
+* Accessible via
+  * In their most detailed form, you'd need access to the cloud consoles themselves, but most of the data is also available in our Grafana instance.  [Here is one of our dashboards hitting CloudWatch for metrics](https://earthangel-b40313e5.influxcloud.net/d/HqOQKXoZk/fxa-auth-prod-elb?orgId=1)
+
+# Front-end Performance 
+
+* Example data recorded
+  * It took 400ms to load `/settings`
+* Recorded with
+  * As of this writing we record the data using our own library (which maybe isn't totally accurate) and write the data via `statsd` which ends up in influxdb.  We expect to move to [Sentry Performance](https://sentry.io/for/performance/) soon
+* Accessible via
+  * Look for the `svcops_aws` project in Grafana.  [Here is a dashboard with some examples](https://earthangel-b40313e5.influxcloud.net/d/1tthDDrWk/content-server?orgId=1)

--- a/sidebars.js
+++ b/sidebars.js
@@ -34,6 +34,7 @@ module.exports = {
                             'how-tos/managing-yarn-dependencies',
                             'how-tos/connecting-to-a-local-mysql-db',
                             'how-tos/using-a-custom-profile-with-firefox',
+                            'how-tos/working-with-metrics',
                            ],
           'Reference':     [
                               {
@@ -74,6 +75,7 @@ module.exports = {
                             },
                            ],          
           'Explanation':   [
+                            'explanation/metrics',                
                             'explanation/onepw-protocol',
                             'explanation/scoped-keys',
                             'explanation/content-server-architecture',


### PR DESCRIPTION
This changes our metrics docs from being a monolithic "metrics.md" and tries to embrace the [divio system](https://documentation.divio.com/introduction/) the docs are modeled after.  I wrote the reference one from scratch so it has some stuff which might be new to some folks.  The other two pages are mostly from the old docs, but I updated them to remove amplitude and redshift references and brought our history doc up to date.