### PR TITLE
feat: add static storybook links

### DIFF
--- a/docs/reference/emails.md
+++ b/docs/reference/emails.md
@@ -51,7 +51,7 @@ Mailer.prototype.verifyLoginCodeEmail = async function (message) {
 }
 ```
 
-`layout` defaults to `fxa`. Pass in `layout: 'subscription'` at the same level `headers` and `template` is at (_outside_ of the `templateValues` object) for the SubPlat layout. 
+`layout` defaults to `fxa`. Pass in `layout: 'subscription'` at the same level `headers` and `template` is at (_outside_ of the `templateValues` object) for the SubPlat layout.
 
 Corresponding MJML/EJS:
 ```html
@@ -74,12 +74,12 @@ Emails have a "campaign" assigned to them in a key/value map in `email.js`, as w
 
 ### Previewing Emails and Storybook
 
-To quickly preview all emails, run `yarn storybook` in the auth-server. We maintain Storybook for all FxA emails as a single source of truth for documentation; every email should have a clear description noting when and why we send the email, and all email states should be accounted for when updating or creating a new email template.
+You can quickly preview all emails [here](https://storage.googleapis.com/mozilla-storybooks-fxa/commits/latest/fxa-auth-server/index.html), or alternatively run `yarn storybook` in the auth-server. We maintain Storybook for all FxA emails as a single source of truth for documentation; every email should have a clear description noting when and why we send the email, and all email states should be accounted for when updating or creating a new email template.
 
 Check out our docs on [Storybook deploys with CircleCI](../reference/storybook-deploys-with-circleci.md) for details on how to preview changes in PRs or to send a link out to anyone who may need to see FxA email copy or documentation.
 
 :::note
-Emails previewed in HTML are meant to be a rough representation of what an email will look like in an email client. They're essentially identical and MJML helps us with consistency, but keep in mind you're previewing in a browser when emails may be viewed in email clients in practice. 
+Emails previewed in HTML are meant to be a rough representation of what an email will look like in an email client. They're essentially identical and MJML helps us with consistency, but keep in mind you're previewing in a browser when emails may be viewed in email clients in practice.
 :::
 
 We couple Storybook with the `merge-ftl` grunttask to display strings from our `en.ftl` files (see the l10n section for more details). At the time of writing, Storybook is our way to preview or manually check the English strings we ultimately pass to translators, and our tests cover the English fallback copy.

--- a/docs/reference/storybook-deploys-with-circleci.md
+++ b/docs/reference/storybook-deploys-with-circleci.md
@@ -4,6 +4,8 @@ title: Storybook Deploys with CircleCI
 
 Several of the packages in this repository use [Storybook](https://storybook.js.org/) to build and demonstrate user interface components (mostly in React). These notably include [fxa-settings](#UPDATE-ME), [fxa-payments-server](#UPDATE-ME), and [fxa-react](#UPDATE-ME).
 
+The latest Storybook builds on the main branch, can be found [here](https://storage.googleapis.com/mozilla-storybooks-fxa/commits/latest/index.html).
+
 For most [test runs in CircleCI](https://github.com/mozilla/fxa/blob/main/.circleci/config.yml), a static build of each package's Storybook for the relevant commit is published to a website we host on Google Cloud Platform. [Click here](https://storage.googleapis.com/mozilla-storybooks-fxa/index.html) to view the index page.
 
 :::tip

--- a/docs/reference/tests-in-circleci.md
+++ b/docs/reference/tests-in-circleci.md
@@ -134,14 +134,6 @@ This is the base Dockerfile for the container used by most jobs. It includes mos
 
 **Note:** If you commit an update to this Dockerfile, try not to include changes to other parts of the project in the same Pull Request. Other jobs in the same test run are likely to lag behind and use the previous version of the fxa-circleci container, because the current test run will not have had a chance to finish deploying the new image.
 
-### \_scripts/gh-pages.sh
-
-Builds documentation and commits the result to [the gh-pages branch of the repo](https://github.com/mozilla/fxa/tree/gh-pages).
-
-This, in turn, publishes the result to mozilla.github.io/fxa - which currently includes:
-
-- [Storybook for fxa-payments-server](http://mozilla.github.io/fxa/fxa-payments-server/)
-
 ### .circleci/config.yml
 
 Contains general configuration, job definitions, and workflows orchestrating all the jobs.

--- a/docs/relying-parties/reference/sub-plat-overview.md
+++ b/docs/relying-parties/reference/sub-plat-overview.md
@@ -22,6 +22,16 @@ Importantly, subscriptions are not locked to any one FxA-attached product by def
 
 If a user cancels their subscription, this metadata goes away and your product can go back to treating them as a non-subscribed user.
 
+## Previews
+
+For a preview of the different pages and components that make up the Subscription Platform, as well as emails sent to customers, we have Storybook builds available.
+
+- [Pages and components](https://storage.googleapis.com/mozilla-storybooks-fxa/commits/latest/fxa-payments-server/index.html)
+  - [Checkout with existing Firefox Account](https://storage.googleapis.com/mozilla-storybooks-fxa/commits/latest/fxa-payments-server/index.html?path=/story/routes-product--subscribing-with-new-account)
+  - [Checkout without Firefox Account](https://storage.googleapis.com/mozilla-storybooks-fxa/commits/latest/fxa-payments-server/index.html?path=/story/routes-checkout--subscribing-with-a-new-account)
+  - [Subscription Management](https://storage.googleapis.com/mozilla-storybooks-fxa/commits/latest/fxa-payments-server/index.html?path=/story/routes-subscriptions--subscribed-with-web-subscription)
+- [Email templates](https://storage.googleapis.com/mozilla-storybooks-fxa/commits/latest/fxa-auth-server/index.html?path=/story/subplat-emails-templates)
+
 ## Terminology
 
 Before diving into [features](sub-plat-features.md) and [integration](../tutorials/integration-with-subscription-platform.md) how-tos, it's useful to align on key terminology.


### PR DESCRIPTION
Because:

* There's a static link available to the latest Storybook builds on main

This commit:

* Updates a few links.
* Remove section of deleted script.
* Adds a new section to Sub Plat overview mentioning Storybook.

Closes #