### PR TITLE
Small tweaks on local Sentry, storybook CI, release process

### DIFF
--- a/docs/how-tos/using-sentry-locally.md
+++ b/docs/how-tos/using-sentry-locally.md
@@ -8,7 +8,7 @@ FxA uses [sentry.io](https://sentry.io) to monitor errors and performance in pro
 - Auditing performance / errors after exploratory testing, functional testing, or a load test.
 - Gaining a better understanding of calls made by a certain workflow or endpoint. 
 
-To enable sentry for local development, simply set these environment variables to their respective DSN settings. When these variables are defined, sentry will be activated. 
+To enable sentry for local development, simply set these environment variables in your root-level `.env` file (that you may need to create) to their respective DSN settings. When these variables are defined, sentry will be activated. 
 
 - SENTRY_ENV=local
 - [SENTRY_DSN_ADMIN_PANEL](https://sentry.io/settings/mozilla/projects/fxa-admin-panel/keys/)
@@ -23,7 +23,7 @@ To enable sentry for local development, simply set these environment variables t
 - [SENTRY_DSN_BROWSERID](https://sentry.io/settings/mozilla/projects/fxa-browserid-verify/keys/)
 
 :::tip
-Each variable name links to the sentry.io page containing the DSN value. Asking a fellow engineer for the settings might be the fastest route though... 
+Each variable name links to the sentry.io page containing the DSN value you need to set. Asking a fellow engineer for a copy-and-paste of the environment variables and their values might be the fastest route though... 
 :::
 
 Once the local environment is configured, stop and start the FxA stack and proceed with exploratory testing. Then go to [sentry.io](https://sentry.io), log in with SSO, and [filter to the local environment](https://docs.sentry.io/product/sentry-basics/environments/). Performance stats and errors from your system will be visible.

--- a/docs/reference/storybook-deploys-with-circleci.md
+++ b/docs/reference/storybook-deploys-with-circleci.md
@@ -2,16 +2,22 @@
 title: Storybook Deploys with CircleCI
 ---
 
-Several of the packages in this repository use [Storybook](https://storybook.js.org/) to build and demonstrate user interface components (mostly in React). These notably include [fxa-settings](#UPDATE-ME), [fxa-payments-server](#UPDATE-ME), and [fxa-react](#UPDATE-ME).
+import storybookCI from '../assets/storybook-circleci.png';
 
-The latest Storybook builds on the main branch, can be found [here](https://storage.googleapis.com/mozilla-storybooks-fxa/commits/latest/index.html).
+Several of the packages in this repository use [Storybook](https://storybook.js.org/) to build and demonstrate user interface components (mostly in React). These notably include [fxa-settings](https://github.com/mozilla/fxa/tree/main/packages/fxa-settings), [fxa-payments-server](https://github.com/mozilla/fxa/tree/main/packages/fxa-payments-server), [fxa-react](https://github.com/mozilla/fxa/tree/main/packages/fxa-react), and [fxa-auth-server](https://github.com/mozilla/fxa/tree/main/packages/fxa-auth-server/lib/senders/emails) which contains our emails.
+
+:::info
+The latest Storybook builds on the `main` branch can [be found here](https://storage.googleapis.com/mozilla-storybooks-fxa/commits/latest/index.html).
+:::
 
 For most [test runs in CircleCI](https://github.com/mozilla/fxa/blob/main/.circleci/config.yml), a static build of each package's Storybook for the relevant commit is published to a website we host on Google Cloud Platform. [Click here](https://storage.googleapis.com/mozilla-storybooks-fxa/index.html) to view the index page.
 
-:::tip
 You can find the Storybook build associated with a given commit on GitHub by clicking the "Details" link next to a **storybooks: pull request** check, accessible via clicking the green check mark next to the commit title.
 
-![Example showing how to preview a Storybook build](../assets/storybook-circleci.png)
+<img src={storybookCI} alt="Example showing how to preview a Storybook build" width="400px" />
+
+:::tip
+Since Storybook builds per commit, it can be helpful to send Storybook links around to Product, UX, or anyone else that may want to preview UI changes for a PR you have up before it's approved and merged.
 :::
 
 ## Maintaining Storybook Builds

--- a/docs/reference/team-processes/release-process.md
+++ b/docs/reference/team-processes/release-process.md
@@ -123,10 +123,12 @@ There are a few different ways to handle a dot release. Git is a flexible tool h
     - A teammate to review exactly what's going into the release
     - Confirmation that CI will pass before tagging
 1. After approval and CI pass, merge the PR
-1. Ensure you have the latest from the train branch, including tags, especially if you did not perform the original release or previous dot release for this train. If `git fetch [remote]` doesn't reflect the latest tag, run `git fetch [remote] --tags`.
+1. Check back into the train branch and ensure you have the latest, including tags, especially if you did not perform the original release or previous dot release for this train. If `git fetch [remote]` doesn't reflect the latest tag, run `git fetch [remote] --tags`.
 1. Run `git log` to ensure you see the expected cherry-picked commit(s). The patch command assumes that the relevant commit has been merged into the train branch locally and bumps the the minor version on the last tag it finds in the tree from HEAD.
-1. Tag with the patch release command on the train branch, `./release.sh patch`
+1. Tag with the patch release command **on the train branch**, `./release.sh patch`
 1. Reference everything at and under the instructions beginning with "Do some manual checks" for [a regular release](#a-regular-release). Keep in mind the diff will be against `origin/train-###`, and instead of creating a new Bugzilla deploy bug, you'll copy the output and paste it in the existing bug.
+  - Be sure to open a PR from the train branch back into `main` and merge it once approved
+  - While we prefer one train branch PR into `main` per patch release for reviewing purposes, it's okay for there to be multiple releases in this PR if a previous patch release wasn't reviewed and merged back into `main` before tagging the new patch release
 
 <details>
     <summary>See a diagram of a patch release with the <code>uplift</code> approach, including what <code>./release.sh patch</code> does</summary>


### PR DESCRIPTION
-Couple more details on the RO page based on a couple of questions a new RO recently had
-Minor Sentry page tweaks based on a question recently asked around root-level `.env`
-Storybook CI page tweaks, the image was huge and we needed links to the packages, and placed the "latest" link in an admonition