### PR TITLE
fix: Development setup secrets links

### DIFF
--- a/docs/tutorials/development-setup.mdx
+++ b/docs/tutorials/development-setup.mdx
@@ -202,8 +202,8 @@ When developing locally you may need to set up some secrets in order to effectiv
 
 Check out the Secrets section in the following package documentation:
 
-- [fxa-auth-server](#UPDATE-ME)
-- [fxa-payments-server](#UPDATE-ME)
+- [fxa-auth-server](https://github.com/mozilla/fxa/tree/main/packages/fxa-auth-server#secrets)
+- [fxa-payments-server](https://github.com/mozilla/fxa/tree/main/packages/fxa-payments-server#secrets)
 
 ## Testing
 


### PR DESCRIPTION
This fixes the links for secrets setup listed in the development setup guide.

Both links now point at their respective READMEs