### PR TITLE
docs(swagger): Add Customs Server API docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -39,6 +39,10 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
             spec: 'https://api.accounts.firefox.com/swagger.json',
             route: '/api',
           },
+          {
+            spec: 'https://graphql.accounts.firefox.com/swagger.json',
+            route: '/api-customs-server',
+          },
         ],
         option: {
           sortTagsAlphabetically: true,

--- a/sidebars.js
+++ b/sidebars.js
@@ -10,10 +10,10 @@ module.exports = {
                         'relying-parties/tutorials/integration-with-fxa',
                         'relying-parties/tutorials/integration-with-subscription-platform',
                         'relying-parties/tutorials/pairing',                        
-                     ],
+                    ],
         'How-to Guides': [
                           'relying-parties/how-twos/end-to-end-encryption',
-                         ],
+                        ],
         'Reference': [
                       'relying-parties/reference/metrics-for-relying-parties',
                       'relying-parties/reference/sub-plat-overview',
@@ -22,10 +22,20 @@ module.exports = {
                       'relying-parties/reference/using-apis',
                       {
                         type: 'link',
-                        label: '⚙️ API Reference',
+                        label: '⚙️ Auth Server API Reference',
                         href: '/api',
+                      },
+                      {
+                        type: 'link',
+                        label: '⚙️ OAuth Server API Reference',
+                        href: '/api#tag/OAuth-Server-API-Overview',
+                      },
+                      {
+                        type: 'link',
+                        label: '⚙️ Customs Server API Reference',
+                        href: '/api-customs-server',
                       }
-                     ],
+                    ],
       },
       ]
     },
@@ -37,7 +47,7 @@ module.exports = {
         {
           'Tutorials': ['tutorials/development-setup',
                         'tutorials/subscription-platform',
-                       ],
+                      ],
           'How-to Guides': [
                             'how-tos/creating-an-account-locally',
                             'how-tos/local-emails-with-maildev',
@@ -48,7 +58,7 @@ module.exports = {
                             'how-tos/using-a-custom-profile-with-firefox',
                             'how-tos/working-with-metrics',
                             'how-tos/using-sentry-locally',
-                           ],
+                          ],
           'Reference':     [
                               {
                                 type: 'category',
@@ -98,14 +108,14 @@ module.exports = {
                               label: "Telemetry Data Docs",
                               href: "https://docs.telemetry.mozilla.org/datasets/fxa.html"
                             },
-                           ],
+                          ],
           'Explanation':   [
                             'explanation/metrics',                
                             'explanation/onepw-protocol',
                             'explanation/scoped-keys',
                             'explanation/content-server-architecture',
                             'explanation/session-tokens',
-                           ],
+                        ],
         },
         'additional-docs',
     ]


### PR DESCRIPTION
# Because:

- we implemented Swagger in Customs Server to auto-generate its documentation

# This pull requests:

- adds the Swagger JSON file to Ecosystem Platform to display Customs Server API documentation

# Screenshots
<img width="442" alt="Screen Shot 2022-09-22 at 10 24 05 AM" src="https://user-images.githubusercontent.com/28129806/191773365-81c820b7-434d-490f-90d1-7bcecd21a4c5.png">

<img width="1676" alt="Screen Shot 2022-09-22 at 10 11 51 AM" src="https://user-images.githubusercontent.com/28129806/191770286-437512b9-5297-43e7-9d38-92f2975d41b8.png">
