### PR TITLE
chore(docs): fix README bullet point and link from diagrams

### DIFF
--- a/architecture-diagrams/README.md
+++ b/architecture-diagrams/README.md
@@ -40,7 +40,7 @@ password: password
 
 1. In structurizr, click on `Diagrams` on the right side
 2. In the top menu, click the `PNG` icon to export
-3. Select the following options and click `Export all diagrams`:
-   a. Include diagram title, description, and metadata
-   b. Automatically download
+3. Select the following options and click `Export all diagrams` with:
+   - Include diagram title, description, and metadata
+   - Automatically download
 4. Copy images into `static/diagrams` directory

--- a/docs/reference/system-diagrams.md
+++ b/docs/reference/system-diagrams.md
@@ -8,6 +8,8 @@ Current as of `February 1st, 2023`
 
 The software architecture diagrams in FxA and SubPlat use the [c4 model](https://c4model.com) to separate layers and [structurizr](https://structurizr.com/) to render them.
 
+Instructions for working on these can be found in the [architecture README](https://github.com/mozilla/ecosystem-platform/tree/master/architecture-diagrams).
+
 ## System Landscapes (Level 1)
 
 System Landscapes Key:


### PR DESCRIPTION
Because:

* The README wasn't rendering the lettered list correctly.
* The system diagrams docs was missing a link to the architecture diagrams README.

This commit:

* Fixes the bullet point list in the architecture diagrams README.
* Adds a link to the architecture diagrams README from the system diagrams docs.