### PR TITLE
fix(docs): Update maildev install command

### DIFF
--- a/docs/how-tos/local-emails-with-maildev.md
+++ b/docs/how-tos/local-emails-with-maildev.md
@@ -7,7 +7,7 @@ If you're interested in receiving emails locally you can use [MailDev](https://w
 1. Install the MailDev CLI globally:
 
     ```shell
-    yarn global add maildev
+    npm i -g maildev
     ```
 
 1. Assuming you have FxA running locally you'll need to stop the `inbox` service: 


### PR DESCRIPTION
Because:

* yarn global is deprecated

This commit:

* Replace with npm in maildev how-to doc

Closes #