### PR TITLE
Update development-setup.mdx to add jq as dependencies

### DIFF
--- a/docs/tutorials/development-setup.mdx
+++ b/docs/tutorials/development-setup.mdx
@@ -51,7 +51,7 @@ Start by installing some essentials:
 
 ```shell
 # Git, curl, libgmp + more
-sudo apt-get install git curl build-essential pkg-config libssl-dev libgmp3-dev
+sudo apt-get install git curl jq build-essential pkg-config libssl-dev libgmp3-dev
 ```
 
 Node.js can be installed in a few ways (including using the [installer](https://nodejs.org/en/download/)). The following commands install the latest version, but you should check out [`.nvmrc`](https://github.com/mozilla/fxa/blob/main/.nvmrc) to see the specific version FxA expects (YMMV using versions greater than it):


### PR DESCRIPTION
I'm not sure if `jq` is installed on ubuntu by default or not, but I was following the ubuntu instruction to install the necessary packages on my Manjaro machine, and I faced some issues during the local setup since I didn't have `jq` installed. I assume other people could benefit from this change as well.