### PR TITLE
chore(docs): simplify nx library creation

### DIFF
--- a/docs/reference/npm-scripts-and-nx.md
+++ b/docs/reference/npm-scripts-and-nx.md
@@ -62,7 +62,7 @@ yarn nx g @nx/js:lib payments-stripe --directory=libs/payments/stripe --importPa
 - Modify `project.json` with the following changes.
 
   <details>
-    <summary>Add build `decleration` option</summary>
+    <summary>Add build `declaration` option</summary>
 
     ```json
     {

--- a/docs/reference/npm-scripts-and-nx.md
+++ b/docs/reference/npm-scripts-and-nx.md
@@ -52,7 +52,7 @@ yarn nx g @nx/js:lib <name of library> --directory=<path/to> --importPath=<TS pa
 
 For example:
 ```
-yarn nx g @nx/node:library payments-stripe --directory=libs/payments/stripe --importPath=@fxa/payments/stripe --bundler=esbuild --unitTestRunner=jest --projectNameAndRootFormat=as-provided
+yarn nx g @nx/js:lib payments-stripe --directory=libs/payments/stripe --importPath=@fxa/payments/stripe --bundler=esbuild --unitTestRunner=jest --projectNameAndRootFormat=as-provided
 ```
 
 ### Post-creation steps

--- a/docs/reference/npm-scripts-and-nx.md
+++ b/docs/reference/npm-scripts-and-nx.md
@@ -188,23 +188,8 @@ yarn nx g @nx/js:lib payments-stripe --directory=libs/payments/stripe --importPa
         "transform": {
           "decoratorMetadata": true,
           "legacyDecorator": true
-        },
-        "keepClassNames": true,
-        "externalHelpers": true,
-        "loose": true
-      },
-      "module": {
-        "type": "commonjs"
-      },
-      "sourceMaps": true,
-      "exclude": [
-        "jest.config.ts",
-        ".*\\.spec.tsx?$",
-        ".*\\.test.tsx?$",
-        "./src/jest-setup.ts$",
-        "./**/jest-setup.ts$",
-        ".*.js$"
-      ]
+        }
+      }
     }
 
     ```


### PR DESCRIPTION
Because:

- Nx library creation instructions need to be updated to match the new build and testing targets.
- Library creation instructions were difficult to parse

This commit:

- Updates the library creation script
- Simplifies and clarifies the creation instructions
- Related code change can be found here, [mozilla/fxa#17133](https://github.com/mozilla/fxa/pull/17133)

Closes #FXA-9879