### PR TITLE
chore(docs): use a different port on localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ cross-app and cross-device experience for users.
 
 ### Working on the Docs
 
-Our documentation is organized following a [Divio strategy](https://documentation.divio.com/).  
+Our documentation is organized following a [Divio strategy](https://documentation.divio.com/).
 If you modify these docs please use that structure.
 
 The site is build using [Docusaurus](https://docusaurus.io/en/) and is automatically
@@ -26,4 +26,4 @@ $> yarn start
 ```
 
 That should open a new browser window automatically, or you can manually browse
-to http://localhost:3000/ecosystem-platform/ to view the docs.
+to http://localhost:3333/ecosystem-platform/ to view the docs.

--- a/docs/how-tos/using-swagger-for-api-documentation.md
+++ b/docs/how-tos/using-swagger-for-api-documentation.md
@@ -58,7 +58,7 @@ To view the hapi-swagger generated JSON file locally:
 To view the API documentation within Ecosystem Platform locally:
 
 - `yarn start` the [Ecosystem Platform](https://github.com/mozilla/ecosystem-platform) repository
-- Go to [localhost:3000/ecosystem-platform/api](http://localhost:3000/ecosystem-platform/api)
+- Go to [localhost:3333/ecosystem-platform/api](http://localhost:3333/ecosystem-platform/api)
 
 :::note
 If you are modifying the Swagger JSON file and want to view the API documentation locally, temporarily use the Swagger JSON file (e.g., `http://localhost:9000/swagger.json`) in the specs array within `docusaurus.config.js`

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "docusaurus start",
+    "start": "docusaurus start --port ${FXA_PLATFORM_DOCS_PORT:-3333}",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",


### PR DESCRIPTION
Because:
 - port 3000 is the dev server port for FxA Settings

This commit:
 - start ecosystem docs on 3333 by default instead