### PR TITLE
chore(docs): Update FxA triage ownership page w/daily update template

### DIFF
--- a/docs/reference/team-processes/triage-process.md
+++ b/docs/reference/team-processes/triage-process.md
@@ -57,6 +57,21 @@ In addition, the FxA triage owner is also responsible for:
 - Assisting with any high priority bugs that come up during the sprint
 - Hanging out in the #fxa Matrix room
 
+See more details for each of these below. The triage owner should post a daily update in the #fxa-team Slack channel which can be copied and pasted and should only take 5-10 minutes:
+
+:::note[Triage owner daily update]
+:jira: New tickets in Jira that we should consider moving up in the backlog, or other updates?  
+:sentry2: Major spikes or issues in Sentry?  
+:grafana-intensifies: Any abnormalities in Grafana? [Handy link 1](https://earthangel-b40313e5.influxcloud.net/d/BeBr8TiIz/fxa-gcp-load-balancers?orgId=1&from=now-3h&to=now&refresh=1m), [handy link 2](https://earthangel-b40313e5.influxcloud.net/d/J81nRFfWz/auth-server?orgId=1&refresh=1m)  
+:slack: Anything in #fxa or #fxa-bots that needs #fxa-team attention?
+:::
+
+:::note[Optionally include these for bonus points]
+:bugzilla-2023: New major bugs or other updates in Bugzilla?
+:matrix-org: Has anything come up in Matrix?  
+:dependabot: Any dependabot updates?
+:::
+
 ### SubPlat
 
 In addition, the SubPlat triage owner is also responsible for:


### PR DESCRIPTION
Happy to make any changes here.

closes FXA-10924 (not sure our Jira link works over here?)

<img width="1039" alt="image" src="https://github.com/user-attachments/assets/b9aa3c0f-7f81-43ea-9f62-5568369ebcdd" />