### PR TITLE
docs: update development setup cache troubleshooting

### DIFF
--- a/docs/tutorials/development-setup.mdx
+++ b/docs/tutorials/development-setup.mdx
@@ -168,6 +168,8 @@ Those need [additional configuration](../tutorials/subscription-platform) also. 
 
 ### Troubleshooting
 
+If the FxA stack has trouble starting after running `yarn start`, (for example, a process hangs or you don't see a success message similar to "# Stack Started Successfully !") try starting without cache: `NX_SKIP_NX_CACHE=true yarn start`. If this solves your issue, you can likely revert to `yarn start` eventually, after cache cleans up.  
+
 Be sure to check the PM2 logs to see what, if any errors are reported.  To do this:
 ```
 yarn pm2 logs


### PR DESCRIPTION
We encountered an issue where the FxA stack has trouble starting after running `yarn start` – the NX process hangs.  This PR documents the issue and adds a potential solution, skipping NX cache.