### PR TITLE
doc(db): update fxa db diagram to patch level 174

### DIFF
--- a/docs/reference/database-structure.md
+++ b/docs/reference/database-structure.md
@@ -3,7 +3,8 @@ title: Database Structure
 ---
 
 Current as of:
-- [FxA db patch level](https://github.com/mozilla/fxa/tree/main/packages/db-migrations/databases/fxa): `172`
+
+- [FxA db patch level](https://github.com/mozilla/fxa/tree/main/packages/db-migrations/databases/fxa): `174`
 - [Oauth db patch level](https://github.com/mozilla/fxa/tree/main/packages/db-migrations/databases/fxa_oauth): `32`
 - [Profile db patch level](https://github.com/mozilla/fxa/tree/main/packages/db-migrations/databases/fxa_profile): `4`
 
@@ -116,6 +117,13 @@ erDiagram
         varchar name
         varchar display_name
         varchar capabilities
+    }
+```
+```mermaid
+erDiagram
+    deletedAccounts {
+       binary uid PK "16 bytes" 
+       bigint deletedAt "unsigned"
     }
 ```
 ```mermaid


### PR DESCRIPTION
Because:

* I added a table named `deletedAccounts` as Data Eng requested in FXA-11655

This commit:

* update fxa db diagrams to patch level 174 to reflect the change