### PR TITLE
doc(metrics): update how-to guide for creating new frontend metrics

### DIFF
--- a/docs/how-tos/working-with-metrics.md
+++ b/docs/how-tos/working-with-metrics.md
@@ -2,7 +2,7 @@
 title: Working with Metrics
 ---
 
-Last updated: `May 21st, 2024`
+Last updated: `July 16th, 2025`
 
 Other relevant documents include our [metrics reference](../reference/metrics) and [metrics explanation](../explanation/metrics).
 
@@ -46,7 +46,7 @@ For event specific properties, we have a `event.reason` string metric to capture
 ### Settings
 
 0. Update the YAML in `packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml`.
-0. Run `yarn glean-generate` from `packages/fxa-shared`.
+0. Run `yarn glean-generate && yarn build` from `packages/fxa-shared`.
 0. Add the event to `eventsMap` in `packages/fxa-shared/metrics/glean/web/index.ts`.
 0. Update `recordEventMetric` in `packages/fxa-settings/src/lib/glean/index.ts` to include the new event in the switch statement.
 


### PR DESCRIPTION
Because:

* we need to rebuild fxa-shared after generating a new glean metric for settings, otherwise unit tests (and possibly other stuff) can error

This commit:

* updates the instruction to include `yarn build`