### PR TITLE
Tidy up the pull-api-definitions workflow

### DIFF
--- a/.github/workflows/pull-api-definitions.yml
+++ b/.github/workflows/pull-api-definitions.yml
@@ -10,10 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone ecosystem-docs code repository
-        uses: actions/checkout@v3
-
-      - name: Set up npm
-        uses: actions/setup-node@v3
+        uses: actions/checkout@v5
 
       - name: Set up Git
         id: setup
@@ -56,6 +53,12 @@ jobs:
       - name: create pull request
         if: steps.diff.outcome == 'failure'
         run: |
-          gh pr create -B master -H pull-api-definitions --title "New API definitions" --body "Updated APIs detected.  Here are some new docs."
+          # The branch is force-pushed every run, so an already-open PR has
+          # picked up the new commit and `gh pr create` would just error out.
+          if gh pr view pull-api-definitions --json state --jq .state 2>/dev/null | grep -q OPEN; then
+            echo "::notice:: PR already open for pull-api-definitions; the force-push updated it."
+          else
+            gh pr create -B master -H pull-api-definitions --title "New API definitions" --body "Updated APIs detected.  Here are some new docs."
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Follow-up to #795. Nothing here is broken — this is cleanup plus one latent-bug fix.

### 1. Removed the `Set up npm` step

`actions/setup-node` was only there for the `npm install @graphql-markdown/docusaurus graphql` line that #795 deleted. Nothing in the workflow runs `node`, `npm`, or `npx` anymore, so it was executing (along with its `Post Set up npm` teardown) for no reason. `git`, `curl`, and `gh` are all preinstalled on `ubuntu-latest`.

### 2. Bumped `actions/checkout` v3 → v5

Every run currently logs:

> Node 20 is being deprecated. This workflow is running with Node 24 by default.

v3 still works via GitHub's compat shim, but that shim won't last forever.

### 3. Guarded `gh pr create` against an already-open PR

The branch is force-pushed on every run, but `gh pr create` errors with *"a pull request for branch ... already exists"* if the previous PR hasn't been merged yet. This hasn't bitten because #786, #787, #789, #790 and #791 were all merged promptly — but if one sits open for a day and the swagger changes again, the push succeeds and the PR step goes red for no good reason.

Now it checks first and just notes that the force-push already updated the open PR.

### Verification

YAML parses cleanly (`js-yaml`) and the new shell block passes `bash -n`. The behavior change only triggers on a path that has never been exercised, so the normal no-changes and changes-detected paths are untouched.