### PR TITLE
docs(rp): document step-up authentication for relying parties

### DIFF
--- a/docs/reference/tokens.md
+++ b/docs/reference/tokens.md
@@ -113,6 +113,15 @@ metadata in two ways:
 
 On the backend, the `verifiedSessionToken` strategy enforces AAL2-level interactions for endpoints considered "sensitive" (e.g. modifying email, 2FA settings, etc.). This means if a user has set up 2FA on one device, they will need to enter their TOTP code on another device to "upgrade" that non-AAL2 session before performing sensitive actions.
 
+This session state is also exposed to relying parties over OAuth. An RP can *require* it with the
+`acr_values=AAL2` and `max_age` authorization parameters, and read the result back from the `acr`,
+`auth_time`, and `amr` claims. See
+[step-up authentication](/relying-parties/how-tos/step-up-authentication).
+
+`lastAuthAt()` on the session token — the source of `auth_time` / `auth_at` — reports
+`max(authAt, verifiedAt)`, so a second-factor challenge partway through a session advances it. It is
+not the password sign-in time.
+
 ### OAuth Refresh Tokens
 
 RPs that wish to obtain long-lived permission to access the user's account data should request
@@ -142,6 +151,16 @@ They're for signin.
 
 See the [OIDC spec](https://openid.net/specs/openid-connect-core-1_0.html#IDToken) and the
 [FxA supported claims](https://accounts.firefox.com/.well-known/openid-configuration).
+
+Alongside the standard `sub`, `aud`, `iat`, `exp`, and `at_hash`, the ID token carries the
+authentication-context claims when the grant has them: `acr` (string, e.g. `AAL2`), `amr` (array of
+method classes, e.g. `["pwd","otp"]`), `auth_time` (seconds since Unix epoch), and the
+FxA-specific `fxa-aal` (number).
+
+:::note
+The discovery document's `claims_supported` list does not currently include `acr`, `amr`, or
+`auth_time`, even though they are emitted. Do not feature-detect from it.
+:::
 
 This token, a JWT, proves that a user's been authenticated (in this case,
 with FxA). It can also be used as the `id_token_hint` query param value in a
@@ -256,6 +275,14 @@ Mozilla accounts largely follows the IETF JWT access token draft spec's
 - `scope` - space separated list of scopes associated with the grant.
 - `sub` - subject, user id. Normally the FxA user id for the user. If the RP uses [Pairwise Pseudonymous Identifiers (PPID)](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/oauth/pairwise-pseudonymous-identifiers.md), will be an identifier that cannot be correlated to either the real FxA userid, or the PPID given out to other RPs.
 - `fxa-subscriptions` - space separated list of subscriptions the user has for the RP. Claim is only present if the user has a subscription with the RP.
+- `acr` - the authenticator assurance level reached by the session that produced the grant, as a
+  string, e.g. `AAL2`. Only present if the grant carries an assurance level.
+- `auth_time` - the time of the session's most recent authentication event, in _seconds_ since Unix
+  epoch. Only present if the grant carries an authentication time.
+
+`acr` and `auth_time` are the RFC 9470 step-up claims. Note that `amr` is **not** included in the
+JWT access token — it appears on the ID token and in introspection responses only. See
+[step-up authentication](/relying-parties/how-tos/step-up-authentication) for the RP-facing view.
 
 Internal Mozilla reliers also have access to the following custom claims:
 

--- a/docs/relying-parties/how-tos/step-up-authentication.md
+++ b/docs/relying-parties/how-tos/step-up-authentication.md
@@ -1,0 +1,325 @@
+---
+id: step-up-authentication
+title: Step-up authentication
+sidebar_label: Step-up Authentication
+---
+
+Last updated: `August 27th, 2026`
+
+Step-up authentication lets a relying party require the user to complete a fresh two-factor
+challenge before a sensitive action, even though the user is already signed in. Mozilla accounts
+implements the authorization-server half of [RFC 9470][rfc9470] (*OAuth 2.0 Step Up Authentication
+Challenge Protocol*) on top of the standard OpenID Connect [`acr_values`][oidc-acr] and
+[`max_age`][oidc-authrequest] request parameters.
+
+## When to use it
+
+Use step-up for operations where a stolen cookie or a leaked token should not be enough on its own:
+
+- Deleting an account, an add-on, or another primary object
+- Adding or removing collaborators
+- Generating or replacing API keys
+- Changing critical settings
+
+Step-up is **not** the same as [`prompt=login`](/relying-parties/reference/query-parameters#prompt).
+`prompt=login` re-prompts for the user's **password**. Step-up deliberately does not ask for a
+password — it asks for a **second factor** (TOTP, a backup authentication code, a recovery phone
+code). Asking for a password again does not prove possession of a second factor, which is the
+property you actually want for an anti-fraud check.
+
+## Requesting elevation
+
+Add either or both of these parameters to your authorization request:
+
+| Parameter | Value | Effect |
+|-----------|-------|--------|
+| `acr_values` | `AAL2` | The grant is only issued if the user's session has reached authentication assurance level 2 — that is, the user has completed a second factor. |
+| `max_age` | Integer, seconds | The grant is only issued if the user's most recent authentication event is no older than this. |
+
+```
+GET https://accounts.firefox.com/authorization
+  ?client_id=<your client id>
+  &redirect_uri=<your redirect uri>
+  &scope=profile
+  &state=<random state>
+  &response_type=code
+  &acr_values=AAL2
+  &max_age=0
+```
+
+If the session already satisfies the request, the user confirms the account they are signed in as
+— the usual "continue as" screen — and is redirected back to you with an authorization code. No
+second-factor challenge is shown. If the session does not satisfy the request, Mozilla accounts
+challenges the user for a second factor first, then completes the redirect as normal.
+
+Note that a step-up request does not send `action`, so the existing signed-in session is reused
+rather than the user being asked to sign in again.
+
+:::note
+`acr_values` is a space-separated list per the OIDC specification, but **`AAL2` is the only value
+Mozilla accounts recognises**. Any other token in the list is silently ignored — it will not produce
+an error and will not change the outcome. Do not rely on unrecognised values being rejected.
+:::
+
+`max_age` is validated as an integer of `0` or greater. There is no upper bound.
+
+### How the round trip looks
+
+```mermaid
+sequenceDiagram
+participant UA as User-Agent<br>(Browser)
+participant FxA as Mozilla accounts
+participant RP as Relying Party
+
+UA->>RP: User requests a sensitive action
+RP->>UA: Redirect to /authorization w/ acr_values=AAL2&max_age=N
+UA->>FxA: Authorization request
+FxA-->>FxA: Compare session AAL and auth event age
+alt Session already satisfies the request
+  FxA->>UA: Confirm signed-in account; no second factor requested
+else Session is below AAL2, or too old
+  FxA->>UA: Prompt for second factor (TOTP / backup code / recovery phone)
+  UA->>FxA: Submit second factor
+  FxA-->>FxA: Refresh the session authentication event
+  FxA->>UA: Redirect back to RP w/ code
+end
+UA->>RP: Redirect w/ code
+RP->>FxA: Exchange code for tokens
+FxA->>RP: Tokens carrying acr and auth_time
+RP-->>RP: Verify acr and auth_time before performing the action
+```
+
+## Choosing a `max_age`
+
+This is the most consequential decision you will make integrating step-up. `max_age` is your only
+control over how *per-transaction* the elevation actually is.
+
+| `max_age` | Behaviour | Use when |
+|-----------|-----------|----------|
+| *omitted* | Elevation is satisfied if the session has **ever** reached AAL2 — possibly weeks ago. Not per-transaction in any meaningful sense. | You only care that the account has 2FA and the user used it at some point in this session. |
+| `0` | Satisfied only by a challenge completed within the last few seconds. Effectively a challenge on every action. | Destructive or irreversible operations. |
+| `60`–`300` | One challenge covers a short burst of related actions. | A multi-step workflow where challenging at each step would be hostile. |
+| `900`+ | A "sudo window". Any authorization request from that session during the window is elevated without a new challenge. | Rarely. Prefer a shorter window plus an explicit re-challenge. |
+
+Two properties are easy to miss and will bite you:
+
+:::warning
+**There is a five-second grace period.** Freshness is evaluated as
+`now - auth_time > max_age + 5`. Without it, `max_age=0` could never be satisfied — the
+challenge-to-redirect round trip always advances the clock past `auth_time`, so the RP would
+re-challenge in an infinite loop. The practical effect is that `max_age=0` means "challenged within
+the last five seconds", not "challenged this instant". For any `max_age` above a minute or so the
+grace period is negligible.
+:::
+
+:::warning
+**Freshness is a property of the user's Mozilla accounts session, not of your relationship with the
+user.** The authentication event is shared across every relying party using that browser session. If
+the user completes a second-factor challenge for another RP, that challenge also satisfies your
+`max_age` for its duration. A short `max_age` narrows this window but does not eliminate it. If you
+need a challenge bound to one specific action, you must additionally track in your own application
+which action the elevation was obtained for.
+:::
+
+## Reading the result
+
+Elevation is reported through three claims. **Which of them you can see depends on where you look:**
+
+| Claim | ID token | JWT access token | Introspection | Format |
+|-------|:--------:|:----------------:|:-------------:|--------|
+| `acr` | yes | yes | yes | String reporting the level *achieved*, `"AAL1"` or `"AAL2"` |
+| `auth_time` | yes | yes | yes | Seconds since the Unix epoch |
+| `amr` | yes | **no** | yes | Array of strings, e.g. `["pwd","otp"]` |
+| `fxa-aal` | yes | no | no | Number, e.g. `2` |
+
+An example introspection response for an elevated access token:
+
+```json
+{
+  "active": true,
+  "scope": "profile",
+  "client_id": "<your client id>",
+  "token_type": "access_token",
+  "acr": "AAL2",
+  "auth_time": 1755648000,
+  "amr": ["pwd", "otp"],
+  "iat": 1755648003000,
+  "exp": 1755649803000
+}
+```
+
+:::warning
+**`auth_time` is in seconds. `iat` and `exp` on the introspection response are in milliseconds.**
+This asymmetry is intentional and retained for backwards compatibility: `auth_time` follows the OIDC
+convention, while `iat`/`exp` predate it on this endpoint. Comparing them directly without
+converting will be wrong by a factor of 1000.
+:::
+
+### Verify the claims yourself
+
+Do not treat a successful redirect as proof that the requirement was met. Check the claims:
+
+```js
+const MAX_AGE_SECONDS = 0;
+const LEEWAY_SECONDS = 5;
+
+function isElevated(claims) {
+  if (claims.acr !== 'AAL2') {
+    return false;
+  }
+  if (typeof claims.auth_time !== 'number') {
+    return false;
+  }
+  const ageSeconds = Math.floor(Date.now() / 1000) - claims.auth_time;
+  return ageSeconds <= MAX_AGE_SECONDS + LEEWAY_SECONDS;
+}
+```
+
+Two reasons this matters. First, a token can reach your resource server by a path that did not
+involve the authorization request you made. Second, `max_age` is enforced at the moment the grant is
+issued, not for the lifetime of the resulting token — an access token minted under `max_age=0` is
+still valid long after the elevation has conceptually expired. **The freshness window is yours to
+enforce.**
+
+### `amr` does not tell you which factor was used
+
+`amr` reports authentication *method classes*, not specific methods. TOTP, backup authentication
+codes, and recovery-phone codes all report as `otp`. If you need to distinguish "the user did
+something recently" you must key off `auth_time` advancing, not off a change in `amr`.
+
+## Which token type will you receive?
+
+Mozilla accounts issues either opaque access tokens or JWT access tokens, decided per client:
+
+- **Opaque tokens (the default).** Most relying parties receive these. They carry no claims — you
+  must call [`/introspect`](/api#tag/OAuth-Server-API-Overview/operation/postIntrospect) to read
+  `acr`, `auth_time`, and `amr`.
+- **JWT access tokens.** Only issued to clients on an explicit allow-list. Validate them locally
+  against the JWKS from the [discovery document][discovery]. Note that `amr` is **not** included in
+  the JWT access token — only `acr` and `auth_time`. If you need `amr`, read it from the ID token.
+
+There is currently no way to discover which of these you will be issued. Confirm it with the Mozilla
+accounts team when you request credentials, or inspect a token: a JWT access token has three
+base64url segments and a `typ` of `at+JWT`, while an opaque token is a plain hex string.
+
+:::note
+Short-lived JWT access tokens are not persisted server-side, so introspecting one returns
+`active: false`. This is by design, not a bug. Clients issued JWT access tokens are expected to
+validate them locally rather than introspect them.
+:::
+
+## Elevation does not survive a token refresh
+
+:::danger
+A token obtained via `grant_type=refresh_token` carries **no** `acr`, **no** `auth_time`, and **no**
+`amr`. Refreshing silently drops the elevation.
+:::
+
+This is deliberate. The authentication event is recorded against the authorization code and copied
+onto the access token minted from it. Refresh tokens store no authentication event at all, and the
+refresh grant never re-evaluates `acr_values` or `max_age` — there is no user present to challenge.
+If elevation survived a refresh, an attacker holding a refresh token could mint elevated tokens
+indefinitely.
+
+The consequence for your integration: **to re-elevate, re-run the authorization flow.** Do not
+refresh. A refreshed token will still introspect as `active: true`, so a check that only looks at
+`active` will pass while the elevation is gone.
+
+## Users who do not have a second factor
+
+If the user has no AAL2 method on their account, Mozilla accounts asks them to enrol one inline
+rather than failing the request. From your side this is invisible — it happens between your redirect
+and the redirect back, and your original OAuth parameters (`state`, `redirect_uri`, `scope`,
+`acr_values`, `max_age`) are carried through the enrolment flow. When the user finishes, they land
+back at your `redirect_uri` with a code, elevated.
+
+You should still handle the case where the user abandons the flow and never returns — treat it the
+same as any other incomplete authorization.
+
+Enrolment is protected by an emailed one-time code: before the user can add a second factor, they
+must confirm a code sent to their account email. A session alone is not enough to enrol a factor and
+complete step-up. From your side this is one more screen in a flow you do not control; the contract
+at your `redirect_uri` is unchanged.
+
+## Step-up with `prompt=none`
+
+[`prompt=none`](/reference/oauth-details#promptnone-support) forbids any user interaction, which is
+directly at odds with a step-up challenge. If you combine the two and the session does not already
+satisfy the requirement, Mozilla accounts cannot challenge the user, so it fails the request instead:
+the user is redirected to your registered `redirect_uri` with
+
+```
+?error=unmet_authentication_requirements&state=<your state>
+```
+
+This is the [RFC 9470][rfc9470] section 5 / [OIDC][oidcuar] failure code. Treat it as "the session is
+not elevated and I must ask interactively" — retry the same request **without** `prompt=none`.
+
+:::note
+This redirect ships with the release containing FXA-12860. Before that release, a `prompt=none`
+step-up request routes the user into an interactive challenge, which the parameter is supposed to
+forbid, and you are never told the request failed.
+:::
+
+## Implementing the resource-server side (RFC 9470 §3)
+
+Everything above covers Mozilla accounts' role as the **authorization server**. RFC 9470 also
+defines a **resource server** role, and that half is yours to implement. If your API is called with
+a token that is valid but insufficiently elevated, answer with a `401` carrying a
+`WWW-Authenticate` challenge that tells the client what to ask for:
+
+```
+HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Bearer error="insufficient_user_authentication",
+  error_description="A second factor is required for this operation",
+  acr_values="AAL2",
+  max_age="0"
+```
+
+The `acr_values` and `max_age` parameters in the challenge are the values the client should send on
+its next authorization request. This is what makes the loop self-describing: your API declares the
+requirement, and the client does not need it hard-coded.
+
+On receiving this specific challenge, the client must **re-run the authorization flow** with those
+parameters.
+
+:::warning
+Do not respond to an `insufficient_user_authentication` challenge by refreshing the access token.
+The general advice in [Handling expired access tokens](/relying-parties/reference/using-apis#handling-expired-access-tokens)
+— refresh first, re-authenticate only if that fails — is correct for an *expired* token and wrong
+for this one. Refreshing produces a token with no elevation at all, so the retry fails identically
+and the user is stuck in a loop. Distinguish the two cases by the `error` value in the
+`WWW-Authenticate` header.
+:::
+
+## Testing
+
+The `123done` test relying party in the [fxa monorepo](https://github.com/mozilla/fxa) exercises the
+full flow against a local or staging stack:
+
+- `GET /api/step_up` sends `acr_values=AAL2` with a configurable `max_age`
+- `GET /api/token_claims` introspects the current access token and shows `acr`, `auth_time`, `amr`
+- `GET /api/refresh_token` demonstrates elevation being dropped by a refresh
+
+## Current limitations
+
+Be aware of these before you design around step-up. Each is tracked and may change.
+
+- **An abandoned interactive challenge tells you nothing.** `unmet_authentication_requirements` is
+  returned for [`prompt=none`](#step-up-with-promptnone) requests only. If the user simply walks away
+  from a second-factor prompt, or backs out of enrolling one, there is no error redirected to your
+  `redirect_uri` — the flow dead-ends in Mozilla accounts. Handle it as a timeout on your side. A
+  ticket for the decline case is expected to follow. (FXA-12860)
+- **The discovery document does not advertise step-up support.**
+  `.well-known/openid-configuration` does not include `acr_values_supported`, and `claims_supported`
+  does not list `acr`, `auth_time`, or `amr`. Do not feature-detect from the discovery document.
+- **Passkey users may be asked to enrol TOTP.** A passkey sign-in produces a session that is already
+  AAL2, but the account-level check does not currently count passkeys as a second factor. A
+  passkey-only user requesting an elevated grant may be routed into TOTP enrolment they do not
+  strictly need. (FXA-14312)
+
+[rfc9470]: https://datatracker.ietf.org/doc/html/rfc9470
+[oidc-acr]: https://openid.net/specs/openid-connect-core-1_0.html#acrSemantics
+[oidc-authrequest]: https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
+[oidcuar]: https://openid.net/specs/openid-connect-unmet-authentication-requirements-1_0.html
+[discovery]: https://accounts.firefox.com/.well-known/openid-configuration

--- a/docs/relying-parties/reference/glossary.md
+++ b/docs/relying-parties/reference/glossary.md
@@ -85,6 +85,29 @@ Note that prospective reliers may want to use this service, and WebPush is not w
 ### MFA
 Multi-Factor Authentication, also known as 2FA.
 
+### AAL
+Authenticator Assurance Level. A numeric indicator of how many *distinct types* of authentication
+factor a session has provided. `AAL1` is a password alone; `AAL2` means the user has also completed
+a second factor such as TOTP, a backup authentication code, or a recovery-phone code. Note that an
+email code does not raise a session to AAL2 — it is the same factor type as a password.
+
+### ACR
+Authentication Context Class Reference. The OIDC mechanism a relying party uses to state what
+strength of authentication it requires, via the `acr_values` request parameter, and by which the
+result is reported back in the `acr` claim. Mozilla accounts recognises a single value, `AAL2`.
+[Ref](/relying-parties/how-tos/step-up-authentication)
+
+### AMR
+Authentication Methods References. An array claim listing the classes of method used to authenticate
+the session, for example `["pwd","otp"]`. It reports method *classes*, not specific methods — TOTP,
+backup codes, and recovery-phone codes all appear as `otp`.
+
+### Step-up authentication
+Requiring a user to complete a fresh second-factor challenge before a sensitive action, even though
+they are already signed in. Requested with the `acr_values` and `max_age` parameters and defined by
+[RFC 9470](https://datatracker.ietf.org/doc/html/rfc9470).
+[Ref](/relying-parties/how-tos/step-up-authentication)
+
 ### GDPR
 [General Data Protection Regulation](https://commission.europa.eu/law/law-topic/data-protection/rules-business-and-organisations_en), EU law governing use of personal data across all member states.
 

--- a/docs/relying-parties/reference/integration-requirements.md
+++ b/docs/relying-parties/reference/integration-requirements.md
@@ -3,11 +3,11 @@ title: Requirements for Integration
 sidebar_label: Integration Requirements
 ---
 
-Last updated: `June 8th, 2023`
+Last updated: `August 27th, 2026`
 
 
 ## Maintain a point of contact 
-We communicate with our relying parties via the [firefox-accounts-notices group](https://groups.google.com/a/mozilla.com/g/firefox-accounts-notices).  You must subscribe to this list.
+We communicate with our relying parties via the [mozilla-accounts-notices group](https://groups.google.com/a/mozilla.com/g/mozilla-accounts-notices).  You must subscribe to this list.
 
 ## Subscribe to and process events
 Mozilla accounts maintains an [event broker which is a webhook delivery system to communicate with relying parties](/relying-parties/tutorials/integration-with-fxa#webhook-events).  You must [register an endpoint to receive events](/relying-parties/tutorials/integration-with-fxa#register-for-webhooks).  See [Account Events](/reference/account-events) for the full list of events and their payloads.  You will receive events you may or may not care about but some events require you to perform actions:

--- a/docs/relying-parties/reference/query-parameters.md
+++ b/docs/relying-parties/reference/query-parameters.md
@@ -2,12 +2,35 @@
 title: Query Parameters
 ---
 
-Current as of `Nov 17th, 2022`
+Current as of `August 20th, 2026`
 
 
 Query parameters are used to pass data from the relying party to Mozilla accounts.
 
 ## OAuth parameters
+
+### `acr_values`
+
+Specifies the [Authentication Context Class Reference][acr] values the session must satisfy before
+a grant is issued. Space-separated, per the OIDC specification.
+
+#### Options
+
+- `AAL2` - Require that the user has completed two-factor authentication (authenticator assurance
+  level 2) for this session. If they have not, they are challenged for a second factor before the
+  authorization completes. This is the only value Mozilla accounts recognises; any other value in
+  the list is silently ignored.
+  See the [step-up authentication guide](/relying-parties/how-tos/step-up-authentication) for more info.
+
+#### When to specify
+
+When authenticating a user for OAuth ahead of a sensitive action, where being signed in is not
+sufficient assurance on its own.
+
+Not compatible with `prompt=none`: a session that does not already meet the requirement cannot be
+challenged without interaction, so the request fails with
+`error=unmet_authentication_requirements`. See
+[step-up with `prompt=none`](/relying-parties/how-tos/step-up-authentication#step-up-with-promptnone).
 
 ### `client_id`
 
@@ -16,6 +39,26 @@ Specify the OAuth client_id of the relier being signed in to.
 #### When to specify
 
 When authenticating a user for OAuth.
+
+### `max_age`
+
+The maximum permissible age, in seconds, of the user's most recent authentication event. If the
+session's last authentication is older than this, the user is challenged for a second factor before
+the authorization completes.
+
+Freshness is evaluated with a five-second grace period, so `max_age=0` means "authenticated within
+the last few seconds" rather than "authenticated this instant". Choosing a value is the main
+trade-off in a step-up integration - see
+[Choosing a `max_age`](/relying-parties/how-tos/step-up-authentication#choosing-a-max_age).
+
+#### Options
+
+An integer of `0` or greater. There is no upper bound.
+
+#### When to specify
+
+When authenticating a user for OAuth and the *recency* of their authentication matters, not only
+that they authenticated at some point. Commonly paired with `acr_values=AAL2`.
 
 ### `prompt`
 
@@ -303,3 +346,5 @@ if they perform a reset password.
 #### When to specify
 
 - /settings/emails
+
+[acr]: https://openid.net/specs/openid-connect-core-1_0.html#acrSemantics

--- a/docs/relying-parties/reference/using-apis.md
+++ b/docs/relying-parties/reference/using-apis.md
@@ -8,7 +8,7 @@ sidebar_label: Using APIs
 
 The Ecosystem Platform provides [some OAuth APIs for relying parties](/api#tag/OAuth-Server-API-Overview) to use while providing OAuth services to customers.  **Relying Parties should only use OAuth API endpoints**.  Usage and expectations are detailed below.  Narrower requirements and rate limits may apply to more specific APIs.
 
-If these rules change significantly we'll notify the [firefox-accounts-notices group](https://groups.google.com/a/mozilla.com/g/firefox-accounts-notices).  If you're using this API please subscribe to that group.
+If these rules change significantly we'll notify the [mozilla-accounts-notices group](https://groups.google.com/a/mozilla.com/g/mozilla-accounts-notices).  If you're using this API please subscribe to that group.
 
 
 ## API versioning
@@ -18,6 +18,28 @@ Mozilla accounts APIs are versioned and breaking changes will be pushed out in n
 ### Minor changes
 
 Mozilla accounts may change existing APIs in non-breaking ways, for example, adding a new field to a JSON response.  It's expected that clients will not fail if new fields are added.
+
+### Behaviour change: `auth_time` and `auth_at` semantics (August 2026)
+
+:::warning
+`auth_time` (in ID tokens, JWT access tokens, and introspection responses) and `auth_at` (in token
+responses) now report **the most recent authentication event on the session**, rather than the
+password sign-in that created it.
+
+Previously these reflected only the point at which the user signed in with their password. If the
+user later completed a second-factor challenge — a TOTP code, a backup authentication code, a
+recovery-phone code — the timestamp did not move. It now does.
+
+This applies to **every relying party**, not only those using
+[step-up authentication](/relying-parties/how-tos/step-up-authentication). It is a correctness fix:
+OIDC defines `auth_time` as "time when the end-user authentication occurred", and a session that had
+a password at T1 and a second factor at T2 authenticated at T2.
+
+**What to check:** if you use `auth_time` or `auth_at` as a proxy for "when this session began" —
+for example to compute a session age, expire something on a schedule, or key a cache — that
+assumption no longer holds. The value can now move forward during a session. Code that treats it as
+"how recently did the user prove who they are" is unaffected and is the intended reading.
+:::
 
 
 ## Global Rate Limits
@@ -56,3 +78,36 @@ The recommended approach is:
 4. If the refresh token request also returns a `401`, the user has disconnected the RP from their account (or their session has been otherwise invalidated). At this point the RP should discard stored tokens and prompt the user to re-authenticate.
 
 Avoid immediately prompting re-authentication on every `401` without first attempting a token refresh — this creates unnecessary friction for users whose access token has simply expired.
+
+This applies to a `401` caused by an expired token. If the response carries a `WWW-Authenticate`
+header with `error="insufficient_user_authentication"`, refreshing will not help — see
+[Handling insufficient authentication](#handling-insufficient-authentication).
+
+## Handling insufficient authentication
+
+A `401` does not always mean your access token expired. A resource server that requires
+[step-up authentication](/relying-parties/how-tos/step-up-authentication) answers with a `401`
+carrying a `WWW-Authenticate` challenge:
+
+```
+HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Bearer error="insufficient_user_authentication",
+  error_description="A second factor is required for this operation",
+  acr_values="AAL2",
+  max_age="0"
+```
+
+**Refreshing the access token is the wrong response to this challenge.** The elevation conveyed by
+`acr` and `auth_time` is deliberately not carried by refresh tokens, so a refreshed token is
+guaranteed to fail the same check — the retry loops without ever succeeding. Instead, re-run the
+authorization flow, passing the `acr_values` and `max_age` from the challenge.
+
+Distinguish the two cases by reading the `error` value out of the `WWW-Authenticate` header:
+
+| `error` | Meaning | Correct response |
+|---------|---------|------------------|
+| absent, or `invalid_token` | The access token is expired or invalid | Refresh, then retry |
+| `insufficient_user_authentication` | The token is valid but the user's authentication is not strong or not recent enough | Re-run the authorization flow with the challenged `acr_values` / `max_age` |
+
+See [step-up authentication](/relying-parties/how-tos/step-up-authentication#implementing-the-resource-server-side-rfc-9470-3)
+for how to emit this challenge from your own resource server.

--- a/docs/relying-parties/tutorials/integrating-with-fxa.md
+++ b/docs/relying-parties/tutorials/integrating-with-fxa.md
@@ -4,7 +4,7 @@ title: Integration with FxA
 sidebar_label: Integration with FxA
 ---
 
-Last updated: `March 18th, 2026`
+Last updated: `August 20th, 2026`
 
 ## Overview
 
@@ -115,6 +115,8 @@ Build the authorization URL with these parameters:
 | `code_challenge_method` | No | Only needed if using PKCE. Only `S256` is supported |
 | `access_type` | Recommended | `online` or `offline` (offline gives refresh tokens) |
 | `action` | Recommended | `email` or `force_auth` |
+| `acr_values` | No | Use `AAL2` to require the user to have completed two-factor authentication. See [step-up authentication](/relying-parties/how-tos/step-up-authentication) |
+| `max_age` | No | Maximum age in seconds of the user's last authentication. Pair with `acr_values` to force a fresh second-factor challenge |
 | `entrypoint` | Recommended | Metrics identifier (coordinate with FxA team) |
 | `utm_campaign` | No | |
 | `utm_source` | No | |
@@ -211,7 +213,7 @@ Before going live:
   - OAuth: `https://oauth.accounts.firefox.com/`
 - [ ] Register production webhook URL
 - [ ] Submitted your service icon
-- [ ] Joined [firefox-accounts-notices][firefox-accounts-notices] mailing list
+- [ ] Joined [mozilla-accounts-notices][mozilla-accounts-notices] mailing list
 
 ## Reference
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -17,6 +17,7 @@ module.exports = {
                           'relying-parties/how-tos/apple-iap',
                           'relying-parties/how-tos/product-metrics',
                           'relying-parties/how-tos/device-registration',
+                          'relying-parties/how-tos/step-up-authentication',
                          ],
         'Reference': [
                       'relying-parties/reference/glossary',


### PR DESCRIPTION
## Description

RP-facing documentation for the step-up authentication work in [FXA-12763](https://mozilla-hub.atlassian.net/browse/FXA-12763) — `acr_values`, `max_age`, and the `acr` / `auth_time` / `amr` claims. None of this was documented anywhere: a grep of `docs/` before this PR found zero occurrences of `acr_values`, `AAL2`, `max_age`, `auth_time`, or "step-up". AMO cannot integrate from what exists today.

**New page** — `relying-parties/how-tos/step-up-authentication.md`:

- When to use it, and how it differs from `prompt=login` (which prompts for a *password*; step-up deliberately does not)
- Requesting elevation, including that `AAL2` is the only recognised `acr_values` token and others are silently ignored
- **Choosing a `max_age`** — the most consequential integration decision, including the five-second leeway and the fact that freshness is a property of the shared browser session, so another RP's challenge can satisfy yours
- Reading the claims, split by token type, with the seconds-vs-milliseconds introspection gotcha and the reason RPs must verify `auth_time` themselves
- Elevation does not survive a token refresh — and a refreshed token still introspects as `active: true`
- Inline enrolment for users with no second factor
- `prompt=none` failing with `unmet_authentication_requirements`
- The **resource-server** `WWW-Authenticate` challenge (RFC 9470 §3), which is the RP's half to implement and was previously unowned by any ticket
- Current limitations, each linked to its tracking ticket

**Existing pages:**

- `query-parameters` — `acr_values` and `max_age` entries
- `using-apis` — a new section distinguishing an `insufficient_user_authentication` 401 from an expired-token 401. The existing advice ("on a 401, refresh") is actively wrong for the former, because elevation is deliberately not carried by refresh tokens, so the retry loops.
- `using-apis` — a callout for the `auth_time` / `auth_at` semantics change from FXA-14308, which affects **every** RP, not only step-up integrators
- `glossary` — AAL, ACR, AMR, step-up authentication
- `tokens` — `acr` / `auth_time` on JWT access tokens, and the ID token claims
- `integrating-with-fxa` — parameters in the Step 2 authorization table

**Drive-by:** corrects the notices list to `mozilla-accounts-notices`. `integration-requirements` and `using-apis` both named `firefox-accounts-notices` and linked to a matching URL; `integrating-with-fxa` also had an undefined link reference.

## Testing

`yarn build` passes with no errors. The only anchor warning on the new page is `/api#tag/...`, the pre-existing class that affects every page linking into the redocusaurus route (`tokens`, `using-apis`, `apple-iap`, `google-iap`, `integration-requirements`).

Every normative claim was verified against `mozilla/fxa@main` rather than the ticket text, which had drifted — `MAX_AGE_LEEWAY_SECONDS = 5`, `lastAuthAt() = max(authAt, verifiedAt)`, the claim distribution across ID token / JWT access token / introspection, the empty `jwtAccessTokens.enabledClientIds` default, the passkey-to-TOTP divert, and the discovery document omitting `acr_values_supported`. `packages/functional-tests/tests/oauth/stepUpAuth.spec.ts` was used as the executable spec.

## Issue(s)

Closes [FXA-12864](https://mozilla-hub.atlassian.net/browse/FXA-12864).

## Notes for reviewers

- The OpenAPI half of FXA-12864 is a separate PR against `mozilla/fxa`; `api-swagger.json` here is a build artifact pulled daily from production by `pull-api-definitions.yml`, so it is deliberately untouched.
- The `prompt=none` section documents behaviour from mozilla/fxa#21103, which is still in review. It carries a note saying so. **This PR should land after that one**, or that note needs to stay until it does.
- Three known gaps are documented rather than papered over, since AMO will hit them: no RP-visible error when a user abandons an interactive challenge (FXA-12860), the discovery document advertising nothing (unticketed), and passkey users being routed into TOTP enrolment they do not need (FXA-14312).

🤖 Generated with [Claude Code](https://claude.com/claude-code)